### PR TITLE
fix a compiler warning

### DIFF
--- a/bndtools.core/src/bndtools/model/obr/UnresolvedReasonLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/obr/UnresolvedReasonLabelProvider.java
@@ -21,7 +21,7 @@ public class UnresolvedReasonLabelProvider extends RequirementLabelProvider {
     }
 
     public String getLabel(Resource resource) {
-        String resourceName = (resource != null && resource.getId() != null) ? resource.getId() : "«initial»";
+        String resourceName = (resource != null && resource.getId() != null) ? resource.getId() : "<<initial>>";
         return resourceName;
     }
 


### PR DESCRIPTION
[javac] /home/ferry/vcs/pelagic/bndtools/bndtools.core/src/bndtools/model/obr/UnresolvedReasonLabelProvider.java:24: warning: unmappable character for encoding UTF8
    [javac]         String resourceName = (resource != null && resource.getId() != null) ? resource.getId() : "�initial�";
    [javac]                                                                                                    ^
    [javac] /home/ferry/vcs/pelagic/bndtools/bndtools.core/src/bndtools/model/obr/UnresolvedReasonLabelProvider.java:24: warning: unmappable character for encoding UTF8
    [javac]         String resourceName = (resource != null && resource.getId() != null) ? resource.getId() : "�initial�";
    [javac]                                                                                                            ^
