### PR TITLE
Support changing the cnf project without needing to restart Eclipse

### DIFF
--- a/bndtools.core/src/bndtools/Central.java
+++ b/bndtools.core/src/bndtools/Central.java
@@ -187,14 +187,22 @@ public class Central {
     }
 
     public synchronized static Workspace getWorkspace() throws Exception {
-        if (workspace != null)
-            return workspace;
-
         IWorkspace eclipseWorkspace = ResourcesPlugin.getWorkspace();
         IProject cnfProject = eclipseWorkspace.getRoot().getProject("bnd");
 
         if (!cnfProject.exists())
             cnfProject = eclipseWorkspace.getRoot().getProject("cnf");
+
+        if (workspace != null) {
+            if (!cnfProject.exists() || !workspace.getBase().equals(cnfProject.getLocation().toFile().getParentFile())) {
+                workspace.close();
+                workspace = null;
+                workspaceRepo = null;
+                r5Repository = null;
+            } else {
+                return workspace;
+            }
+        }
 
         if (cnfProject.exists()) {
             if (!cnfProject.isOpen())


### PR DESCRIPTION
This change was done as it was found that when trashing projects, and importing new ones in the same eclipse workspace the old bnd workspace would be retained. This was rather unexpected from a new comer.

I am not sure how much value there is to this change, however, I submit the pull request incase someone finds value in the merging of it.
