### PR TITLE
Enable source attachments on libraries in 'Bnd Bundle Classpath'

### DIFF
--- a/bndtools.core/src/bndtools/classpath/BndContainerSourceManager.java
+++ b/bndtools.core/src/bndtools/classpath/BndContainerSourceManager.java
@@ -1,0 +1,190 @@
+package bndtools.classpath;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+
+import bndtools.Central;
+import bndtools.Plugin;
+import bndtools.model.repo.RepositoryUtils;
+
+import aQute.bnd.build.Workspace;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.service.RepositoryPlugin;
+import aQute.bnd.version.Version;
+import aQute.lib.io.IO;
+
+public class BndContainerSourceManager {
+
+    private static final String PROPERTY_SRC_ROOT = ".srcRoot"; //$NON-NLS-1$
+
+    private static final String PROPERTY_SRC_PATH = ".srcPath"; //$NON-NLS-1$
+
+    /**
+     * Persist the attached sources for given {@link IClasspathEntry} instances.
+     */
+    public static void saveAttachedSources(final IJavaProject project, final List<IClasspathEntry> classpathEntries) throws CoreException {
+        final Properties props = new Properties();
+
+        // Construct the Properties that represent the source attachment(s)
+        for (final IClasspathEntry entry : classpathEntries) {
+            if (IClasspathEntry.CPE_LIBRARY != entry.getEntryKind()) {
+                continue;
+            }
+            final String path = entry.getPath().toPortableString();
+            if (entry.getSourceAttachmentPath() != null) {
+                props.put(path + PROPERTY_SRC_PATH, entry.getSourceAttachmentPath().toPortableString());
+            }
+            if (entry.getSourceAttachmentRootPath() != null) {
+                props.put(path + PROPERTY_SRC_ROOT, entry.getSourceAttachmentRootPath().toPortableString());
+            }
+        }
+
+        // Write the properties to a persistent storage area
+        final File propertiesFile = getSourceAttachmentPropertiesFile(project.getProject());
+        if (props.isEmpty()) {
+            IO.delete(propertiesFile);
+        } else {
+            FileOutputStream out = null;
+            try {
+                out = new FileOutputStream(propertiesFile);
+                props.store(out, new Date().toString());
+            } catch (final IOException e) {
+                throw new CoreException(new Status(Status.ERROR, Plugin.PLUGIN_ID, "Failure to write container source attachments", e));
+            } finally {
+                IO.close(out);
+            }
+        }
+    }
+
+    /**
+     * Return (a potentially modified) list of {@link IClasspathEntry} instances that will have any previously persisted
+     * attached sources added.
+     */
+    public static List<IClasspathEntry> loadAttachedSources(final IJavaProject project, final List<IClasspathEntry> classPathEntries) throws CoreException {
+        final Properties props = loadSourceAttachmentProperties(project.getProject());
+
+        final List<IClasspathEntry> configuredClassPathEntries = new ArrayList<IClasspathEntry>(classPathEntries.size());
+
+        for (final IClasspathEntry entry : classPathEntries) {
+            if (entry.getEntryKind() != IClasspathEntry.CPE_LIBRARY || entry.getSourceAttachmentPath() != null) {
+                configuredClassPathEntries.add(entry);
+                continue;
+            }
+
+            final String key = entry.getPath().toPortableString();
+
+            IPath srcPath = null;
+            IPath srcRoot = null;
+
+            // Retrieve the saved source attachment information
+            if (props != null && props.containsKey(key + PROPERTY_SRC_PATH)) {
+                srcPath = Path.fromPortableString((String) props.get(key + PROPERTY_SRC_PATH));
+                if (props.containsKey(key + PROPERTY_SRC_ROOT)) {
+                    srcRoot = Path.fromPortableString((String) props.get(key + PROPERTY_SRC_ROOT));
+                }
+            } else {
+                // If there is no saved source attachment, then try and find a source bundle
+                File sourceBundle = getSourceBundle(entry.getPath());
+                if (sourceBundle != null) {
+                    srcPath = new Path(sourceBundle.getAbsolutePath());
+                }
+            }
+
+            if (srcPath != null || srcRoot != null) {
+                configuredClassPathEntries.add(JavaCore.newLibraryEntry(entry.getPath(), srcPath, srcRoot, entry.getAccessRules(), entry.getExtraAttributes(), entry.isExported()));
+            } else {
+                configuredClassPathEntries.add(entry);
+            }
+        }
+
+        return configuredClassPathEntries;
+    }
+
+    private static File getSourceBundle(IPath path) {
+        Workspace bndWorkspace;
+
+        try {
+            bndWorkspace = Central.getWorkspace();
+            if (bndWorkspace == null) {
+                return null;
+            }
+        } catch (final Exception e) {
+            return null;
+        }
+
+        IPath bundlePath = path;
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IWorkspaceRoot root = workspace.getRoot();
+        IResource resource = root.findMember(path);
+        if (resource != null) {
+            bundlePath = resource.getLocation();
+        }
+
+        Jar jar = null;
+        try {
+            jar = new Jar(bundlePath.toFile());
+
+            String bsn = jar.getBsn();
+            String version = jar.getVersion();
+
+            for (RepositoryPlugin repo : RepositoryUtils.listRepositories(true)) {
+                if (repo == null) {
+                    continue;
+                }
+                File sourceBundle = repo.get(bsn + ".source", new Version(version), null);
+                if (sourceBundle != null) {
+                    return sourceBundle;
+                }
+            }
+        } catch (final Exception e) {
+            // Ignore, something went wrong, or we could not find the source bundle
+        } finally {
+            IO.close(jar);
+        }
+
+        return null;
+    }
+
+    private static Properties loadSourceAttachmentProperties(final IProject project) throws CoreException {
+        final Properties props = new Properties();
+
+        final File propertiesFile = getSourceAttachmentPropertiesFile(project);
+        if (propertiesFile.exists()) {
+            InputStream in = null;
+            try {
+                in = new FileInputStream(propertiesFile);
+                props.load(in);
+            } catch (final IOException e) {
+                throw new CoreException(new Status(Status.ERROR, Plugin.PLUGIN_ID, "Failure to read container source attachments", e));
+            } finally {
+                IO.close(in);
+            }
+        }
+
+        return props;
+    }
+
+    private static File getSourceAttachmentPropertiesFile(final IProject project) {
+        return new File(Plugin.getDefault().getStateLocation().toFile(), project.getName() + ".sources"); //$NON-NLS-1$
+    }
+
+}


### PR DESCRIPTION
The commit supports storing source attachment data (if there is any) for each library exposed via the BndClasspathContainer. The attachment paths are persisted to a properties file per project within the plugin storage location.

There is also primitive support for eclipse style bundle source attachement. Given there are a lot of bundles that have source attachments that follow <bsn>.source I have included the ability to find these bundles from the repositories and auto wire the source attachments up.

It may well be there is a better approach for doing this, my experiences with eclipse plugin development is somewhat limited.

I am open to suggestions for ways to improve it, whatever that be.
