### PR TITLE
JarEditor: move utils package below internal package

### DIFF
--- a/bndtools.jareditor/bnd.bnd
+++ b/bndtools.jareditor/bnd.bnd
@@ -26,7 +26,7 @@ Include-Resource: resources
 	org.eclipse.text
 
 Private-Package: bndtools.jareditor.internal,\
-	bndtools.utils
+	bndtools.jareditor.internal.utils
 	
 Conditional-Package: \
 	aQute.libg.*,\

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JAREditor.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JAREditor.java
@@ -25,7 +25,7 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.ide.ResourceUtil;
 
-import bndtools.utils.SWTConcurrencyUtil;
+import bndtools.jareditor.internal.utils.SWTConcurrencyUtil;
 
 public class JAREditor extends FormEditor implements IResourceChangeListener {
 

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/Printer.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/Printer.java
@@ -28,7 +28,7 @@ import aQute.bnd.osgi.Verifier;
 import aQute.lib.collections.SortedList;
 import aQute.lib.io.IO;
 import aQute.libg.generics.Create;
-import bndtools.utils.CollectionUtil;
+import bndtools.jareditor.internal.utils.CollectionUtil;
 
 public class Printer extends Processor {
 

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/utils/CollectionUtil.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/utils/CollectionUtil.java
@@ -1,4 +1,4 @@
-package bndtools.utils;
+package bndtools.jareditor.internal.utils;
 
 import java.util.Collection;
 import java.util.Map;

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/utils/SWTConcurrencyUtil.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/utils/SWTConcurrencyUtil.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Neil Bartlett - initial API and implementation
  *******************************************************************************/
-package bndtools.utils;
+package bndtools.jareditor.internal.utils;
 
 import org.eclipse.swt.widgets.Display;
 


### PR DESCRIPTION
To have a self-contained 'jareditor' namespace.

in preparation for splitting it off as a separate product

Signed-off-by: Ferry Huberts ferry.huberts@pelagic.nl
