### PR TITLE
Fixed issue #477

### DIFF
--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -2,7 +2,7 @@
 -pluginpath: ${workspace}/cnf/plugins/biz.aQute.repository/biz.aQute.repository-2.0.2.jar
 
 ## Eclipse SDK 3.5.2
-eclipse-repo: aQute.bnd.deployer.repository.FixedIndexedRepo;locations='file:${workspace}/cnf/eclipse-3.5.2/repository.xml';name=Eclipse SDK 3.5.2
+eclipse-repo: aQute.bnd.deployer.repository.FixedIndexedRepo;locations='file:///${workspace}/cnf/eclipse-3.5.2/repository.xml';name=Eclipse SDK 3.5.2
 
 ## Eclipse SDK 4.2RC4
 #eclipse-repo: aQute.lib.deployer.obr.OBR;locations='https://s3.amazonaws.com/eclipse-obr-4.2RC4/repository.xml';name=Eclipse SDK 4.2RC4


### PR DESCRIPTION
As the title says I have changed the line 5 from:

```
eclipse-repo: aQute.bnd.deployer.repository.FixedIndexedRepo;locations='file:${workspace}/cnf/eclipse-3.5.2/repository.xml';name=Eclipse SDK 3.5.2
```

to

```
eclipse-repo: aQute.bnd.deployer.repository.FixedIndexedRepo;locations='file:///${workspace}/cnf/eclipse-3.5.2/repository.xml';name=Eclipse SDK 3.5.2
```

by adding `///` after `file:`.

Now the location is also appropriate for Windows OS.
