### PR TITLE
Allow launchers to work when workspace has space in it

### DIFF
--- a/bndtools.core/src/bndtools/launch/OSGiRunLaunchDelegate.java
+++ b/bndtools.core/src/bndtools/launch/OSGiRunLaunchDelegate.java
@@ -44,6 +44,7 @@ public class OSGiRunLaunchDelegate extends AbstractOSGiLaunchDelegate {
     protected void initialiseBndLauncher(ILaunchConfiguration configuration, Project model) throws Exception {
         synchronized (model) {
             bndLauncher = model.getProjectLauncher();
+            bndLauncher.setSupportEclipse(true);
         }
         configureLauncher(configuration);
         bndLauncher.prepare();


### PR DESCRIPTION
Turn on support for eclipse in project launcher. This was added to allow launching from a workspace that has a name in it. Eclipse launchers handles arguments in such a way that needed to be handled specially.

This change goes with this bnd pull request: https://github.com/bndtools/bnd/pull/290
