### PR TITLE
Allow spaces in workspace directory pathing

### DIFF
--- a/bndtools.core/src/bndtools/launch/OSGiRunLaunchDelegate.java
+++ b/bndtools.core/src/bndtools/launch/OSGiRunLaunchDelegate.java
@@ -44,6 +44,17 @@ public class OSGiRunLaunchDelegate extends AbstractOSGiLaunchDelegate {
     protected void initialiseBndLauncher(ILaunchConfiguration configuration, Project model) throws Exception {
         synchronized (model) {
             bndLauncher = model.getProjectLauncher();
+
+            Collection<String> runvmArgs = bndLauncher.getRunVM();
+
+            // this loop keeps the same order and adds quotes when there's a space.
+            for (String str : runvmArgs) {
+                runvmArgs.remove(str);
+                if (str.contains(" ")) {
+                    str = "\"" + str + "\"";
+                }
+                runvmArgs.add(str);
+            }
         }
         configureLauncher(configuration);
         bndLauncher.prepare();


### PR DESCRIPTION
Add quotes around runVM arguments that have spaces. This allows eclipse to launch run and debug launchers if a workspace has a space in it.

This builds off of bnd pull request https://github.com/bndtools/bnd/pull/293
