### PR TITLE
Created BndWorkspaceRepository, which hooks into the "BND" workspace.

### DIFF
--- a/bndtools.core/src/bndtools/BndWorkspaceRepository.java
+++ b/bndtools.core/src/bndtools/BndWorkspaceRepository.java
@@ -1,0 +1,104 @@
+package bndtools;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+import org.osgi.service.log.LogService;
+import org.osgi.service.repository.Repository;
+
+import bndtools.api.ILogger;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.deployer.repository.CapabilityIndex;
+import aQute.bnd.deployer.repository.api.IRepositoryContentProvider;
+import aQute.bnd.deployer.repository.api.IRepositoryIndexProcessor;
+import aQute.bnd.deployer.repository.api.Referral;
+import aQute.bnd.deployer.repository.providers.R5RepoContentProvider;
+import aQute.lib.io.IO;
+
+public class BndWorkspaceRepository implements Repository {
+
+    private final Map<Project,CapabilityIndex> projectMap = new HashMap<Project,CapabilityIndex>();
+    private final IRepositoryContentProvider contentProvider = new R5RepoContentProvider();
+
+    private final URI workspaceRootUri = ResourcesPlugin.getWorkspace().getRoot().getLocationURI();
+    private final ILogger logger = Logger.getLogger();
+    private final LogService logAdapter = new LogServiceAdapter(logger);
+
+    public void init() throws Exception {
+        for (Project model : Central.getWorkspace().getAllProjects()) {
+            File targetDir = model.getTarget();
+            if (targetDir != null) {
+                File indexFile = new File(targetDir, ".index");
+                if (indexFile != null && indexFile.isFile()) {
+                    loadProjectIndex(model, new FileInputStream(indexFile));
+                }
+            }
+        }
+    }
+
+    public void loadProjectIndex(final Project project, InputStream index) {
+        synchronized (projectMap) {
+            try {
+                cleanProject(project);
+
+                IRepositoryIndexProcessor processor = new IRepositoryIndexProcessor() {
+                    public void processResource(Resource resource) {
+                        addResource(project, resource);
+                    }
+
+                    public void processReferral(URI parentUri, Referral referral, int maxDepth, int currentDepth) {
+                        // ignore: we don't create any referrals
+                    }
+                };
+                contentProvider.parseIndex(index, workspaceRootUri, processor, logAdapter);
+            } catch (Exception e) {
+                logger.logError(MessageFormat.format("Failed to process index file for bundles in project {0}.", project.getName()), e);
+            } finally {
+                IO.close(index);
+            }
+        }
+    }
+
+    private void cleanProject(Project project) {
+        CapabilityIndex index = projectMap.get(project);
+        if (index != null)
+            index.clear();
+    }
+
+    private void addResource(Project project, Resource resource) {
+        CapabilityIndex index = projectMap.get(project);
+        if (index == null) {
+            index = new CapabilityIndex();
+            projectMap.put(project, index);
+        }
+        index.addResource(resource);
+    }
+
+    public Map<Requirement,Collection<Capability>> findProviders(Collection< ? extends Requirement> requirements) {
+        Map<Requirement,Collection<Capability>> result = new HashMap<Requirement,Collection<Capability>>();
+        for (Requirement requirement : requirements) {
+            List<Capability> matches = new LinkedList<Capability>();
+            result.put(requirement, matches);
+
+            for (Entry<Project,CapabilityIndex> entry : projectMap.entrySet()) {
+                CapabilityIndex capabilityIndex = entry.getValue();
+                capabilityIndex.appendMatchingCapabilities(requirement, matches);
+            }
+        }
+        return result;
+    }
+}

--- a/bndtools.core/src/bndtools/Central.java
+++ b/bndtools.core/src/bndtools/Central.java
@@ -30,7 +30,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.osgi.framework.Version;
 import bndtools.api.ILogger;
-
 import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.build.WorkspaceRepository;
@@ -43,6 +42,8 @@ public class Central {
     static Workspace workspace = null;
     static WorkspaceR5Repository r5Repository = null;
     static RepositoryPlugin workspaceRepo = null;
+
+    private static BndWorkspaceRepository bndRepository;
 
     static final AtomicBoolean indexValid = new AtomicBoolean(false);
     static final ConcurrentMap<String,Map<String,SortedSet<Version>>> exportedPackageMap = new ConcurrentHashMap<String,Map<String,SortedSet<Version>>>();
@@ -179,6 +180,16 @@ public class Central {
         return r5Repository;
     }
 
+    public synchronized static BndWorkspaceRepository getBndWorkspaceRepository() throws Exception {
+        if (bndRepository != null)
+            return bndRepository;
+
+        bndRepository = new BndWorkspaceRepository();
+        bndRepository.init();
+
+        return bndRepository;
+    }
+
     public synchronized static RepositoryPlugin getWorkspaceRepository() throws Exception {
         if (workspaceRepo != null)
             return workspaceRepo;
@@ -212,6 +223,7 @@ public class Central {
         workspace.addBasicPlugin(new WorkspaceListener(workspace));
         workspace.addBasicPlugin(Activator.instance.repoListenerTracker);
         workspace.addBasicPlugin(getWorkspaceR5Repository());
+        workspace.addBasicPlugin(getBndWorkspaceRepository());
 
         // Initialize projects in synchronized block
         workspace.getBuildOrder();

--- a/bndtools.core/src/bndtools/classpath/BndContainerInitializer.java
+++ b/bndtools.core/src/bndtools/classpath/BndContainerInitializer.java
@@ -245,7 +245,12 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
                     errors.add(String.format("Failed to convert file %s to Eclipse path", file));
                 }
                 if (p != null) {
-                    if (c.getType() == Container.TYPE.PROJECT) {
+
+                    //[cs] if it's a project, but not in the eclipse workspace, then make
+                    // it a "LibraryEntry"
+                    IJavaProject j = Central.getJavaProject(c.getProject());
+
+                    if (c.getType() == Container.TYPE.PROJECT && j != null) {
                         IResource resource = ResourcesPlugin.getWorkspace().getRoot().getFile(p);
                         List<IAccessRule> rules = projectAccessRules.get(c.getProject());
                         IAccessRule[] accessRules = null;

--- a/bndtools.core/src/org/bndtools/core/jobs/newproject/NewProjectResourceListener.java
+++ b/bndtools.core/src/org/bndtools/core/jobs/newproject/NewProjectResourceListener.java
@@ -38,6 +38,11 @@ public class NewProjectResourceListener implements IResourceChangeListener {
                         IProject project = (IProject) resource;
                         if (project.isOpen() && project.hasNature(BndProjectNature.NATURE_ID) && ((delta.getKind() & IResourceDelta.ADDED) != 0)) {
                             newProjects.add(project);
+                        } else if ((delta.getKind() & IResourceDelta.REMOVED) != 0) {
+                            newProjects.add(project);
+                        } else if ((delta.getKind() & IResourceDelta.CHANGED) != 0 && (delta.getFlags() & IResourceDelta.OPEN) != 0) {
+                            // If resource changed its open or closed state.
+                            newProjects.add(project);
                         }
                     }
 


### PR DESCRIPTION
This allows you to reference projects in your bnd workspace that
might not be in your eclipse workspace OR might be closed in your
eclipse workspace.

Adjusted NewProjectResourceListener to turn project references into
.jar file references when a project is closed or removed from eclipse.
Likewise a .jar file reference is turned back into a project reference
if a project is opened in eclipse too.

All of this is useful if you have a subset of your total number of
projects where changes are occurring. You can minimize what all
gets rebuilt as you make changes.

I know this isn't as "pluginable" as one would like, however, I ran into problems attempting to put this into the bndtools.plugins project. If this is really where it should go, there were several bndtools.core packages that weren't exported to allow it.

Comments welcome :)
