### PR TITLE
Fixed path to biz.aQute.repository jar file referenced in repositories.bnd.

### DIFF
--- a/bndtools.repository.base/templates/cnfs/default/ext/repositories.bnd
+++ b/bndtools.repository.base/templates/cnfs/default/ext/repositories.bnd
@@ -1,6 +1,6 @@
 plugindir: ${workspace}/cnf/plugins
 
--pluginpath: ${plugindir}/biz.aQute.repository/biz.aQute.repository-2.0.2.jar
+-pluginpath: ${plugindir}/biz.aQute.repository/biz.aQute.repository-2.0.3.jar
 
 -plugin:\
 	aQute.bnd.deployer.repository.LocalIndexedRepo; name=Release;      local=${workspace}/cnf/releaserepo;pretty=true,\


### PR DESCRIPTION
File referenced was an older version than the file in the repository (2.0.2 vs 2.0.3).
