### PR TITLE
Prevent partially initialized Bnd Workspace(s)

### DIFF
--- a/bndtools.core/src/bndtools/Central.java
+++ b/bndtools.core/src/bndtools/Central.java
@@ -19,7 +19,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
-import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -191,32 +190,46 @@ public class Central {
         if (workspace != null)
             return workspace;
 
-        IWorkspace eclipseWorkspace = ResourcesPlugin.getWorkspace();
-        IProject cnfProject = eclipseWorkspace.getRoot().getProject("bnd");
+        Workspace newWorkspace = null;
 
+        try {
+            newWorkspace = Workspace.getWorkspace(getWorkspaceDirectory());
+
+            newWorkspace.addBasicPlugin(new WorkspaceListener(newWorkspace));
+            newWorkspace.addBasicPlugin(Activator.instance.repoListenerTracker);
+            newWorkspace.addBasicPlugin(getWorkspaceR5Repository());
+
+            // Initialize projects in synchronized block
+            newWorkspace.getBuildOrder();
+
+            // The workspace has been initialized fully, set the field now
+            workspace = newWorkspace;
+
+            return workspace;
+        } catch (final Exception e) {
+            if (newWorkspace != null) {
+                newWorkspace.close();
+            }
+            throw e;
+        }
+    }
+
+    private static File getWorkspaceDirectory() throws CoreException {
+        IWorkspaceRoot eclipseWorkspace = ResourcesPlugin.getWorkspace().getRoot();
+
+        IProject cnfProject = eclipseWorkspace.getProject("bnd");
         if (!cnfProject.exists())
-            cnfProject = eclipseWorkspace.getRoot().getProject("cnf");
+            cnfProject = eclipseWorkspace.getProject("cnf");
 
         if (cnfProject.exists()) {
             if (!cnfProject.isOpen())
                 cnfProject.open(null);
-            File cnfDir = cnfProject.getLocation().toFile();
-            workspace = Workspace.getWorkspace(cnfDir.getParentFile());
-        } else {
-            // Have to assume that the eclipse workspace == the bnd workspace,
-            // and cnf hasn't been imported yet.
-            File workspaceDir = eclipseWorkspace.getRoot().getLocation().toFile();
-            workspace = Workspace.getWorkspace(workspaceDir);
+            return cnfProject.getLocation().toFile().getParentFile();
         }
 
-        workspace.addBasicPlugin(new WorkspaceListener(workspace));
-        workspace.addBasicPlugin(Activator.instance.repoListenerTracker);
-        workspace.addBasicPlugin(getWorkspaceR5Repository());
-
-        // Initialize projects in synchronized block
-        workspace.getBuildOrder();
-
-        return workspace;
+        // Have to assume that the eclipse workspace == the bnd workspace,
+        // and cnf hasn't been imported yet.
+        return eclipseWorkspace.getLocation().toFile();
     }
 
     public void changed(Project model) {


### PR DESCRIPTION
It is possible during the creation of a Bnd Workspace to have an exception thrown, resulting in a partially initialized Bnd Workspace.

This change ensures that a Bnd Workspace will only be retained if it was fully initialized, in the failure case it will ensure that the workspace is closed.

This partially initialized case manifested itself by the user not being able to resolve runbundles against the workspace r5 repository.

Recreating the partially initialized case is easy.
1. Create a new workspace
2. Create a Bnd OSGi bundle along with the 'cnf' project outside of the eclipse workspace
3. Switch to Bnd perspective
4. Restart Eclipse
5. Try to resolve bundles for running against the workspace repository (its not in the list of repositories you can resolve from).

Further investigation into this indicated that the "Repositories" view was being instantiated, during this an Exception was being thrown (getWorkspaceR5Repository threw an Exception) that was being caught (and swallowed). The result was that the workspace stored in the "workspace" field (which would be subsequently returned for all getWorkspace() calls) did not have the Workspace Repository plugin, also the getBuildOrder() on the workspace also would not be called.

I should add that I am running this in Eclipse 4.2 (Juno)
