### PR TITLE
Fix For Launching Jar Viewer On Cached Jar Files From Repositories View

### DIFF
--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleVersion.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleVersion.java
@@ -1,6 +1,7 @@
 package bndtools.model.repo;
 
 import java.io.File;
+import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Map;
 
@@ -43,21 +44,19 @@ public class RepositoryBundleVersion implements IAdaptable, Actionable {
     public Object getAdapter(@SuppressWarnings("rawtypes") Class adapter) {
         Object result = null;
 
-        if (IFile.class.equals(adapter)) { // ||
-                                           // IResource.class.equals(adapter))
-                                           // {
-            File file = getFile();
-            if (file != null) {
+        File file = getFile();
+        if (file != null) {
+            if (IFile.class.equals(adapter)) { // ||
+                // IResource.class.equals(adapter))
+                // {
+                // Note that if the file is outside the workspace the IFile result will be null
                 IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
                 result = root.getFileForLocation(new Path(file.getAbsolutePath()));
-                // If result is null it means that the file is outside the workspace.
-                // Just return the file instead.
-                if (result == null) {
-                    result = file;
-                }
+            } else if (File.class.equals(adapter)) {
+                result = file;
+            } else if (URI.class.equals(adapter)) {
+                result = file.toURI();
             }
-        } else if (File.class.equals(adapter)) {
-            result = getFile();
         }
 
         return result;

--- a/bndtools.core/src/bndtools/views/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/RepositoriesView.java
@@ -3,6 +3,7 @@ package bndtools.views;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -204,18 +205,14 @@ public class RepositoriesView extends ViewPart implements RepositoryListenerPlug
                 if (!event.getSelection().isEmpty()) {
                     IStructuredSelection selection = (IStructuredSelection) event.getSelection();
                     if (selection.getFirstElement() instanceof IAdaptable) {
-                        Object fileObject = ((IAdaptable) selection.getFirstElement()).getAdapter(IFile.class);
-                        if (fileObject != null) {
+                        URI uri = (URI) ((IAdaptable) selection.getFirstElement()).getAdapter(URI.class);
+                        if (uri != null) {
                             IWorkbenchPage page = getSite().getPage();
                             try {
-                                if (fileObject instanceof IFile) {
-                                    IDE.openEditor(page, (IFile) fileObject);
-                                } else if (fileObject instanceof File) {
-                                    IFileStore fileStore = EFS.getLocalFileSystem().getStore(((File) fileObject).toURI());
-                                    IDE.openEditorOnFileStore(page, fileStore);
-                                }
+                                IFileStore fileStore = EFS.getLocalFileSystem().getStore(uri);
+                                IDE.openEditorOnFileStore(page, fileStore);
                             } catch (PartInitException e) {
-                                logger.logError("Error opening editor for " + fileObject, e);
+                                logger.logError("Error opening editor for " + uri, e);
                             }
                         }
                     }


### PR DESCRIPTION
Previously if I double-clicked on a JAR file hosted in a remote repository in the Repositories view, nothing would happen.

Nothing would happen because it is not possible to create an IFile for a file outside the Eclipse workspace.

To fix I changed RepositoryBundleVersion to return a File if the IFile could not be created.

I then changed the Repositories view to support both IFile and File (File is converted to an IFileStore). Note that whilst it works I am not sure it is the right way to do this (e.g. getAdapter(IFile.class) apparently can also return a File?, rather than supporting Files and IFiles would it be better to just use Files?).
