### PR TITLE
Fix for issue #722

### DIFF
--- a/bndtools.core/src/bndtools/editor/project/RunFrameworkPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunFrameworkPart.java
@@ -182,7 +182,6 @@ public class RunFrameworkPart extends BndEditorPart implements PropertyChangeLis
 
     @Override
     public void commitToModel(boolean onSave) {
-        super.commit(onSave);
         try {
             committing = true;
             model.setRunFw(selectedFramework.trim().length() > 0 ? selectedFramework.trim() : null);


### PR DESCRIPTION
This should fix issue #722 - stack overflow when saving a bndrun editor.
