### PR TITLE
Enable variables in -runrequires

### DIFF
--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -102,12 +102,23 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 
     private final Map<String,IFormPageFactory> pageFactories = new LinkedHashMap<String,IFormPageFactory>();
 
-    private final BndEditModel model = new BndEditModel();
-    private final BndSourceEditorPage sourcePage = new BndSourceEditorPage(SOURCE_PAGE, this);
+    private final BndEditModel model;
+    private final BndSourceEditorPage sourcePage;
 
     private final Image buildFileImg = AbstractUIPlugin.imageDescriptorFromPlugin(Plugin.PLUGIN_ID, "icons/bndtools-logo-16x16.png").createImage();
 
     public BndEditor() {
+        BndEditModel model2;
+        try {
+            model2 = new BndEditModel(Central.getWorkspace());
+        } catch (Exception e) {
+            System.err.println("Unable to create BndEditModel with Workspace, defaulting to without Workspace");
+            model2 = new BndEditModel();
+        }
+        model = model2;
+
+        sourcePage = new BndSourceEditorPage(SOURCE_PAGE, this);
+
         pageFactories.put(WORKSPACE_PAGE, WorkspacePage.MAIN_FACTORY);
         pageFactories.put(WORKSPACE_EXT_PAGE, WorkspacePage.EXT_FACTORY);
         pageFactories.put(CONTENT_PAGE, BundleContentPage.FACTORY);

--- a/bndtools.core/src/bndtools/wizards/bndfile/EnableSubBundlesOperation.java
+++ b/bndtools.core/src/bndtools/wizards/bndfile/EnableSubBundlesOperation.java
@@ -29,6 +29,7 @@ import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.properties.Document;
 import bndtools.Plugin;
+import bndtools.central.Central;
 
 public class EnableSubBundlesOperation implements IWorkspaceRunnable {
 
@@ -63,8 +64,13 @@ public class EnableSubBundlesOperation implements IWorkspaceRunnable {
             throw newCoreException("Container path does not exist", null);
 
         // Create new project model
-        BndEditModel newBundleModel = new BndEditModel();
-
+        BndEditModel newBundleModel;
+        try {
+            newBundleModel = new BndEditModel(Central.getWorkspace());
+        } catch (Exception e) {
+            System.err.println("Unable to create BndEditModel with Workspace, defaulting to without Workspace");
+            newBundleModel = new BndEditModel();
+        }
         // Load project file and model
         IFile projectFile = container.getProject().getFile(Project.BNDFILE);
         BndEditModel projectModel;
@@ -76,7 +82,12 @@ public class EnableSubBundlesOperation implements IWorkspaceRunnable {
             } else {
                 projectDocument = new Document("");
             }
-            projectModel = new BndEditModel();
+            try {
+                projectModel = new BndEditModel(Central.getWorkspace());
+            } catch (Exception e) {
+                System.err.println("Unable to create BndEditModel with Workspace, defaulting to without Workspace");
+                projectModel = new BndEditModel();
+            }
             projectModel.loadFrom(projectDocument);
         } catch (IOException e) {
             throw new CoreException(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, e.getMessage(), e));

--- a/bndtools.core/src/bndtools/wizards/project/AbstractNewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/AbstractNewBndProjectWizard.java
@@ -75,7 +75,12 @@ abstract class AbstractNewBndProjectWizard extends JavaProjectWizard {
             "static-method", "unused"
     })
     protected BndEditModel generateBndModel(IProgressMonitor monitor) {
-        return new BndEditModel();
+        try {
+            return new BndEditModel(Central.getWorkspace());
+        } catch (Exception e) {
+            logger.logError("Unable to create BndEditModel with Workspace, defaulting to without Workspace", e);
+            return new BndEditModel();
+        }
     }
 
     /**

--- a/bndtools.core/src/org/bndtools/core/ui/resource/R5LabelFormatter.java
+++ b/bndtools.core/src/org/bndtools/core/ui/resource/R5LabelFormatter.java
@@ -144,7 +144,12 @@ public class R5LabelFormatter {
     private static Pattern getFilterPattern(String name) {
         Pattern pattern = FILTER_PATTERNS.get(name);
         if (pattern == null) {
-            pattern = Pattern.compile("\\(" + name + "[<>]?=([^\\)]*)\\)");
+            // Group match #1 is used in applyPattern() down below.
+            if (name.contains("$")) {
+                pattern = Pattern.compile("\\{(.*?)\\}");
+            } else {
+                pattern = Pattern.compile("\\(" + Pattern.quote(name) + "[<>]?=([^\\)]*)\\)");
+            }
             Pattern existing = FILTER_PATTERNS.putIfAbsent(name, pattern);
             if (existing != null)
                 pattern = existing;

--- a/bndtools.core/src/org/bndtools/core/ui/wizards/blueprint/BlueprintXmlFileWizard.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/blueprint/BlueprintXmlFileWizard.java
@@ -46,6 +46,7 @@ import aQute.bnd.build.model.clauses.HeaderClause;
 import aQute.bnd.osgi.Builder;
 import aQute.libg.glob.Glob;
 import bndtools.Plugin;
+import bndtools.central.Central;
 import bndtools.editor.BndEditor;
 import bndtools.editor.model.IDocumentWrapper;
 
@@ -195,7 +196,7 @@ public class BlueprintXmlFileWizard extends Wizard implements INewWizard {
         if (editor instanceof BndEditor) {
             editModel = ((BndEditor) editor).getEditModel();
         } else {
-            editModel = new BndEditModel();
+            editModel = new BndEditModel(Central.getWorkspace());
             doc = FileUtils.readFully(bndFile);
             editModel.loadFrom(new IDocumentWrapper(doc));
         }

--- a/bndtools.release/src/bndtools/release/ReleaseHelper.java
+++ b/bndtools.release/src/bndtools/release/ReleaseHelper.java
@@ -46,6 +46,7 @@ import aQute.bnd.properties.Document;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.version.Version;
 import aQute.service.reporter.Reporter;
+import bndtools.central.Central;
 import bndtools.release.api.IReleaseParticipant;
 import bndtools.release.api.ReleaseOption;
 import bndtools.release.api.IReleaseParticipant.Scope;
@@ -97,8 +98,16 @@ public class ReleaseHelper {
 				document = new Document(""); //$NON-NLS-1$
 			}
 
-			final BndEditModel model = new BndEditModel();
-			model.loadFrom(document);
+            final BndEditModel model;
+            BndEditModel model2;
+            try {
+                model2 = new BndEditModel(Central.getWorkspace());
+            } catch (Exception e) {
+                System.err.println("Unable to create BndEditModel with Workspace, defaulting to without Workspace");
+                model2 = new BndEditModel();
+            }
+            model = model2;
+            model.loadFrom(document);
 
 			String currentVersion = model.getBundleVersionString();
 			String templateVersion = updateTemplateVersion(currentVersion, bundleVersion);


### PR DESCRIPTION
This goes with https://github.com/bndtools/bnd/pull/465

It uses the updates to BndEditModel to allow variables in the -runrequires settings in .bndrun files. This is all facilitated through having access to a Macro object, which ends up requiring the Workspace object (at least that was the easiest path forward)
