### PR TITLE
Remove exact duplicates from RunBundles after resolution wizard finishes

### DIFF
--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
@@ -94,6 +94,11 @@ public class ResolutionWizard extends Wizard {
             List<VersionedClause> runBundles = new ArrayList<VersionedClause>(resources.size());
             for (Resource resource : resources) {
                 VersionedClause runBundle = resourceToRunBundle(resource);
+
+                //[cs] Skip dups
+                if (runBundles.contains(runBundle)) {
+                    continue;
+                }
                 runBundles.add(runBundle);
 
                 if (pathsStream != null) {
@@ -120,7 +125,6 @@ public class ResolutionWizard extends Wizard {
                         r2 = "";
                     return r1.compareTo(r2);
                 }
-
             });
             model.setRunBundles(runBundles);
         } finally {


### PR DESCRIPTION
We saw a case where a resolution was returning bsn;version=1.2.3.4 and bsn;version=1.2.3.5 back from felix. (I had to debug into the code to see this).
The -runbundles listing was getting updated with bsn;version='[1.2.3,1.3.0)',bsn;version='[1.2.3,1.3.0)' which was causing an error when you tried to run it. (i.e. both of those bsn and version ranges are the same)

I thought instead of having it include the same runbundles entry twice, dups should be filtered out.

It's quite possible that we versioned 1.2.3.5 incorrectly and it should have been 1.2.4 in order to make the tooling would work out "right", but this seemed like a decent change nevertheless.
