### PR TITLE
Better dark-theme support in Luna+

### DIFF
--- a/bndtools.core/src/bndtools/editor/BndSourceEditorPage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEditorPage.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
@@ -113,7 +114,7 @@ public class BndSourceEditorPage extends TextEditor implements IFormPage {
         super.initializeEditor();
         setDocumentProvider(new BndSourceDocumentProvider());
         setRulerContextMenuId("#BndSourceRulerContext");
-        setSourceViewerConfiguration(new BndSourceViewerConfiguration(getSharedColors()));
+        setSourceViewerConfiguration(new BndSourceViewerConfiguration(JavaUI.getColorManager()));
     }
 
     public boolean isActive() {

--- a/bndtools.core/src/bndtools/editor/completion/BndSourceViewerConfiguration.java
+++ b/bndtools.core/src/bndtools/editor/completion/BndSourceViewerConfiguration.java
@@ -4,6 +4,8 @@ import java.util.*;
 
 import org.bndtools.core.editors.BndMarkerAnnotationHover;
 import org.bndtools.core.editors.BndMarkerQuickAssistProcessor;
+import org.eclipse.jdt.ui.text.IColorManager;
+import org.eclipse.jdt.ui.text.IJavaColorConstants;
 import org.eclipse.jface.text.*;
 import org.eclipse.jface.text.contentassist.*;
 import org.eclipse.jface.text.presentation.*;
@@ -12,7 +14,6 @@ import org.eclipse.jface.text.quickassist.QuickAssistAssistant;
 import org.eclipse.jface.text.rules.*;
 import org.eclipse.jface.text.source.*;
 import org.eclipse.swt.*;
-import org.eclipse.swt.graphics.*;
 
 public class BndSourceViewerConfiguration extends SourceViewerConfiguration {
 
@@ -30,14 +31,14 @@ public class BndSourceViewerConfiguration extends SourceViewerConfiguration {
     BndScanner scanner;
     MultiLineCommentScanner multiLineCommentScanner;
 
-    public BndSourceViewerConfiguration(ISharedTextColors colors) {
-        T_DEFAULT = new Token(new TextAttribute(colors.getColor(new RGB(0, 0, 0))));
-        T_MACRO = new Token(new TextAttribute(colors.getColor(new RGB(0, 255, 0)), null, SWT.BOLD));
-        T_ERROR = new Token(new TextAttribute(colors.getColor(new RGB(255, 0, 0)), null, SWT.BOLD));
-        T_COMMENT = new Token(new TextAttribute(colors.getColor(new RGB(128, 0, 0))));
-        T_INSTRUCTION = new Token(new TextAttribute(colors.getColor(new RGB(0, 0, 255)), null, SWT.BOLD));
-        T_OPTION = new Token(new TextAttribute(colors.getColor(new RGB(0, 0, 255))));
-        T_DIRECTIVE = new Token(new TextAttribute(colors.getColor(new RGB(60, 60, 255)), null, SWT.BOLD));
+    public BndSourceViewerConfiguration(IColorManager colorManager) {
+        T_DEFAULT = new Token(new TextAttribute(colorManager.getColor(IJavaColorConstants.JAVA_DEFAULT)));
+        T_MACRO = new Token(new TextAttribute(colorManager.getColor(IJavaColorConstants.TASK_TAG), null, SWT.BOLD));
+        T_ERROR = new Token(new TextAttribute(colorManager.getColor(IJavaColorConstants.JAVA_KEYWORD), null, SWT.BOLD));
+        T_COMMENT = new Token(new TextAttribute(colorManager.getColor(IJavaColorConstants.JAVA_SINGLE_LINE_COMMENT)));
+        T_INSTRUCTION = new Token(new TextAttribute(colorManager.getColor(IJavaColorConstants.JAVADOC_KEYWORD), null, SWT.BOLD));
+        T_OPTION = new Token(new TextAttribute(colorManager.getColor(IJavaColorConstants.JAVADOC_LINK), null, SWT.BOLD));
+        T_DIRECTIVE = new Token(new TextAttribute(colorManager.getColor(IJavaColorConstants.JAVADOC_KEYWORD), null, SWT.BOLD));
     }
 
     @Override


### PR DESCRIPTION
Using java color constants that support dark-theme in Luna+.  Here are screenshots of default and dark themes for Luna using Ubuntu 14.04.

![screenshot from 2014-07-18 00 04 53](https://cloud.githubusercontent.com/assets/595221/3616047/b30ff2ce-0dce-11e4-98ce-4893108dcbb1.png)
![screenshot from 2014-07-18 00 05 08](https://cloud.githubusercontent.com/assets/595221/3616048/b32d8d98-0dce-11e4-97d0-506e15aabbd2.png)
