### PR TITLE
[resolver] Update launchTemplates to skip osgi.service requirements by default

### DIFF
--- a/bndtools.core/resources/unprocessed/launchTemplates/equinox37+console.bndrun
+++ b/bndtools.core/resources/unprocessed/launchTemplates/equinox37+console.bndrun
@@ -2,6 +2,6 @@
 -runee: JavaSE-1.7
 -runsystemcapabilities: ${native_capability}
 
--resolve.effective: active
+-resolve.effective: active;skip:="osgi.service"
 
 -runvm: -Dosgi.console

--- a/bndtools.core/resources/unprocessed/launchTemplates/equinox37+gogo+ds.bndrun
+++ b/bndtools.core/resources/unprocessed/launchTemplates/equinox37+gogo+ds.bndrun
@@ -2,7 +2,7 @@
 -runee: JavaSE-1.7
 -runsystemcapabilities: ${native_capability}
 
--resolve.effective: active
+-resolve.effective: active;skip:="osgi.service"
 
 -runbundles:\
 	org.eclipse.equinox.ds,\

--- a/bndtools.core/resources/unprocessed/launchTemplates/felix4+shell.bndrun
+++ b/bndtools.core/resources/unprocessed/launchTemplates/felix4+shell.bndrun
@@ -2,7 +2,7 @@
 -runee: JavaSE-1.7
 -runsystemcapabilities: ${native_capability}
 
--resolve.effective: active
+-resolve.effective: active;skip:="osgi.service"
 
 -runbundles:\
 	org.apache.felix.gogo.runtime,\

--- a/bndtools.core/resources/unprocessed/launchTemplates/felix4+webconsole.bndrun
+++ b/bndtools.core/resources/unprocessed/launchTemplates/felix4+webconsole.bndrun
@@ -2,7 +2,7 @@
 -runee: JavaSE-1.7
 -runsystemcapabilities: ${native_capability}
 
--resolve.effective: active
+-resolve.effective: active;skip:="osgi.service"
 
 -runbundles:\
 	org.apache.felix.gogo.runtime,\

--- a/bndtools.core/resources/unprocessed/launchTemplates/felix4.bndrun
+++ b/bndtools.core/resources/unprocessed/launchTemplates/felix4.bndrun
@@ -2,4 +2,4 @@
 -runee: JavaSE-1.7
 -runsystemcapabilities: ${native_capability}
 
--resolve.effective: active
+-resolve.effective: active;skip:="osgi.service"


### PR DESCRIPTION
This pull request provides part of the proposed fix for issue #859 - the other half is in bndtools/bnd/pull/546
