### PR TITLE
gradle: No longer need to tell bnd to delay run dependencies

### DIFF
--- a/cnf/gradle/init.gradle
+++ b/cnf/gradle/init.gradle
@@ -42,11 +42,6 @@ if (workspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }
 
-/* Delay run dependency evaluations since they may not yet be built */
-workspace.allProjects.each {
-  it.setDelayRunDependencies(true)
-}
-
 /* Add cnf project to the graph */
 include bnd_cnf
 

--- a/org.bndtools.headless.build.plugin.gradle/resources/templates/unprocessed/cnf/gradle/init.gradle
+++ b/org.bndtools.headless.build.plugin.gradle/resources/templates/unprocessed/cnf/gradle/init.gradle
@@ -42,11 +42,6 @@ if (workspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }
 
-/* Delay run dependency evaluations since they may not yet be built */
-workspace.allProjects.each {
-  it.setDelayRunDependencies(true)
-}
-
 /* Add cnf project to the graph */
 include bnd_cnf
 


### PR DESCRIPTION
https://github.com/bndtools/bnd/pull/591 changed bnd to make the default
that run dependencies are delayed.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
