### PR TITLE
#841 Fix headless build plugins on Windows

### DIFF
--- a/bndtools.utils/src/org/bndtools/utils/copy/bundleresource/BundleResourceCopier.java
+++ b/bndtools.utils/src/org/bndtools/utils/copy/bundleresource/BundleResourceCopier.java
@@ -25,7 +25,7 @@ public class BundleResourceCopier {
 	}
 
 	private void addOrRemoveDirectoryRecursive(File dstDir, String bundleDir, String relativePath, boolean add) throws IOException {
-		String resourcePath = new File(bundleDir, relativePath).getPath();
+		String resourcePath = formatBundleEntryPath(new File(bundleDir, relativePath).getPath());
 		Enumeration<String> resourcePathEntries = bundle.getEntryPaths(resourcePath);
 		if (resourcePathEntries != null) {
 			while (resourcePathEntries.hasMoreElements()) {
@@ -71,7 +71,7 @@ public class BundleResourceCopier {
 		File dstFile = new File(dstDir, relativePath);
 
 		if (add) {
-			String resourcePath = new File(bundleDir, relativePath).getPath();
+			String resourcePath = formatBundleEntryPath(new File(bundleDir, relativePath).getPath());
 			URL resourceUrl = bundle.getEntry(resourcePath);
 			if (resourceUrl == null) {
 				throw new IOException("Resource " + resourcePath + " not found in bundle " + bundle.getSymbolicName());
@@ -186,5 +186,14 @@ public class BundleResourceCopier {
 		for (String templatePath : relativePaths) {
 			addOrRemoveDirectory(dstDir, bundleDir, templatePath, add);
 		}
+	}
+	
+	private String formatBundleEntryPath(String path) {
+		// Bundle.getEntry* doesn't grok backslashes
+		if (File.separatorChar != '\\') {
+			return path;
+		}
+		
+		return path.replace('\\', '/');
 	}
 }


### PR DESCRIPTION
BundleResourceCopier doesn't take into account that the Windows path separator
is a backslash.  Bundle.getEntryPaths and Bundle.getEntry only deal with
forward slashes, meaning that the GradleHeadlessBuildPlugin and
AntHeadlessBuildPlugin both fail in their respective setup() methods.

So for paths that will end up being passed to getEntryPaths or getEntry, we
simply (and perhaps naively) replace backslashes with forward slashes.

Fixes #841
