### PR TITLE
JPM View: Support the platform default browser

### DIFF
--- a/bndtools.core/src/bndtools/preferences/JpmPreferences.java
+++ b/bndtools.core/src/bndtools/preferences/JpmPreferences.java
@@ -11,16 +11,17 @@ public class JpmPreferences {
     public static final int PREF_BROWSER_WEBKIT = 0;
     public static final int PREF_BROWSER_MOZILLA = 1;
     public static final int PREF_BROWSER_EXTERNAL = 2;
+    public static final int PREF_BROWSER_PLATFORM_DEFAULT = 3;
 
     public static final String[] PREF_BROWSER_SELECTION_CHOICES = new String[] {
-            "Internal WebKit", "Internal Mozilla (requires XULRunner)", "External"
+            "Internal WebKit", "Internal Mozilla (requires XULRunner)", "External", "Platform Default"
     };
 
     private final IPreferenceStore store;
 
     public JpmPreferences() {
         store = Plugin.getDefault().getPreferenceStore();
-        store.setDefault(PREF_BROWSER_SELECTION, 0);
+        store.setDefault(PREF_BROWSER_SELECTION, PREF_BROWSER_PLATFORM_DEFAULT);
     }
 
     public int getBrowserSelection() {

--- a/bndtools.core/src/org/bndtools/core/views/jpm/JPMBrowserView.java
+++ b/bndtools.core/src/org/bndtools/core/views/jpm/JPMBrowserView.java
@@ -85,7 +85,10 @@ public class JPMBrowserView extends ViewPart implements ISelectionListener {
             //            linkToPrefs.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, false));
             stack.topControl = composite;
         } else {
-            if (prefs.getBrowserSelection() == JpmPreferences.PREF_BROWSER_WEBKIT) {
+            if (prefs.getBrowserSelection() == JpmPreferences.PREF_BROWSER_PLATFORM_DEFAULT) {
+                browser = new Browser(parent, SWT.NONE);
+                stack.topControl = browser;
+            } else if (prefs.getBrowserSelection() == JpmPreferences.PREF_BROWSER_WEBKIT) {
                 browser = new Browser(parent, SWT.WEBKIT);
                 stack.topControl = browser;
             } else if (prefs.getBrowserSelection() == JpmPreferences.PREF_BROWSER_MOZILLA) {


### PR DESCRIPTION
SWT on Windows uses Internet Explorer out of the box, and while I
believe it is possible to get WebKit or XULRunner working with some
downloads/configuration changes, it is nice to have this working by
default instead of silently failing.

Add a "Platform Default" option to the JPM browser selection and make it
the default.  This should work on most default installs across platforms
and if it doesn't the user can choose a specific browser engine if they
choose to do so.

Signed-off-by: Sean Bright sean@malleable.com
