### PR TITLE
Minor cosmetic changes to the Release UI

### DIFF
--- a/bndtools.release/src/bndtools/release/ui/BundleTree.java
+++ b/bndtools.release/src/bndtools/release/ui/BundleTree.java
@@ -88,7 +88,6 @@ public class BundleTree extends Composite {
 		sashForm = new SashForm(this, SWT.VERTICAL);
 		sashForm.setLayout(createGridLayout());
         sashForm.setLayoutData(createFillGridData());
-		sashForm.setSashWidth(10);
 
 		createInfoViewer(sashForm);
 
@@ -185,11 +184,12 @@ public class BundleTree extends Composite {
 
 	private void createButtons(Composite parent) {
 
-	    GridLayout gridLayout = createGridLayout();
-	    gridLayout.numColumns = 2;
+	    GridLayout gridLayout = new GridLayout(3, false);
+	    gridLayout.marginWidth = 0;
 
 	    Composite composite = new Composite(parent, SWT.NONE);
 	    composite.setLayout(gridLayout);
+	    
 	    GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 	    gridData.grabExcessHorizontalSpace = true;
 	    composite.setLayoutData(gridData);
@@ -223,23 +223,19 @@ public class BundleTree extends Composite {
 				}
 			}
 		});
+		
+        gridData = new GridData(SWT.END, SWT.CENTER, true, true);
 
-		Composite dropdown = new Composite(composite, SWT.NONE);
-		gridLayout = createGridLayout();
-		gridLayout.numColumns = 2;
-		dropdown.setLayout(gridLayout);
-        gridData = createFillGridData();
-        gridData.grabExcessVerticalSpace = false;
-        gridData.horizontalAlignment = SWT.RIGHT;
-        gridData.grabExcessHorizontalSpace = true;
-	    dropdown.setLayoutData(gridData);
-
-	    Label label = new Label(dropdown, SWT.NONE);
+	    Label label = new Label(composite, SWT.NONE);
 	    label.setText(Messages.releaseOption);
+	    label.setLayoutData(gridData);
 
-		options = new Combo(dropdown, SWT.DROP_DOWN | SWT.READ_ONLY);
-		String items[] = { Messages.updateVersionsAndRelease, Messages.updateVersions, Messages.release };
-		options.setItems(items);
+		options = new Combo(composite, SWT.DROP_DOWN | SWT.READ_ONLY);
+		options.setItems(new String[] {
+		        Messages.updateVersionsAndRelease,
+		        Messages.updateVersions,
+		        Messages.release
+		});
 		options.add(Messages.comboSelectText, 0);
 		options.select(0);
 
@@ -416,6 +412,7 @@ public class BundleTree extends Composite {
 	public ReleaseOption getReleaseOption() {
 	    return ReleaseOption.parse(options.getText());
 	}
+
     private static GridLayout createGridLayout() {
         GridLayout gridLayout = new GridLayout();
         gridLayout.numColumns = 1;

--- a/bndtools.release/src/bndtools/release/ui/WorkspaceReleaseDialog.java
+++ b/bndtools.release/src/bndtools/release/ui/WorkspaceReleaseDialog.java
@@ -48,22 +48,45 @@ public class WorkspaceReleaseDialog extends Dialog implements SelectionListener 
 		this.projectDiffs = projectDiffs;
 		this.showMessage = showMessage;
 	}
+	
+	@Override
+	protected void configureShell(Shell newShell) {
+	    super.configureShell(newShell);
+	    newShell.setText(Messages.releaseDialogTitle);
+	    newShell.setImage(Activator.getImageDescriptor("icons/lorry.png").createImage());
 
+	    int width = 640, height = 480;
+	    int top = -1, left = -1;
+	    
+	    Shell parent = (Shell) newShell.getParent();
+	    
+	    if (parent != null) {
+	        Point parentSize = parent.getSize();
+	        Point parentLocation = parent.getLocation();
+	        
+            width = Math.max(Double.valueOf(parentSize.x * 0.8).intValue(), 640);
+            height = Math.max(Double.valueOf(parentSize.y * 0.8).intValue(), 480);
+            
+            top = parentLocation.y + ((parentSize.y - height) / 2);
+            left = parentLocation.x + ((parentSize.x - width) / 2);
+	    }
+	    
+	    newShell.setSize(width, height);
+
+	    if (top != -1 && left != -1) {
+	        newShell.setLocation(left, top);
+	    }
+	}
+	
 	@Override
 	protected Control createDialogArea(Composite parent) {
 		Composite composite = (Composite) super.createDialogArea(parent);
 
 		GridData gridData = createFillGridData();
 
-		/* take 80% of the application window or 800x500 if that's bigger */
-		Point size = getParentShell().getSize();
-		gridData.widthHint = Math.max(Double.valueOf(size.x * 0.8).intValue(), 800);
-		gridData.heightHint = Math.max(Double.valueOf(size.y * 0.8).intValue(), 500);
-
 	    sashForm = new SashForm(composite, SWT.HORIZONTAL);
 	    sashForm.setLayout(createGridLayout());
 	    sashForm.setLayoutData(gridData);
-	    sashForm.setSashWidth(10);
 
 	    Composite left = new Composite(sashForm, SWT.NONE);
 	    left.setLayout(createGridLayout());
@@ -83,6 +106,8 @@ public class WorkspaceReleaseDialog extends Dialog implements SelectionListener 
 		projectListControl.setInput(projectDiffs);
 
         sashForm.setWeights(new int[] { 40, 60 });
+        
+        sashForm.pack();
 
 		return sashForm;
 	}


### PR DESCRIPTION
- Make the red/green colors less "aggressive"
- Use images for the legend instead of a text field
- Fix padding/margins/alignments in various places
- Use native splitter (sash) widths
- Make the columns in the project list fit things better
- Make the minimum width of the dialog 640x480 instead of 800x500
- Center the dialog over the parent window
- Give the dialog a title on platforms where it is supported
- Give the dialog the lorry icon on platforms where it is supported

Before:
![image](https://cloud.githubusercontent.com/assets/114601/4080712/2cad31d6-2ee1-11e4-874c-e829f596e90d.png)

After:
![image](https://cloud.githubusercontent.com/assets/114601/4080722/33ce12e6-2ee1-11e4-9422-9a99fbfd4ed7.png)

The only thing I could go either way on is the width of the splitter (sash) bars.  I also think the "80% of the width of the parent" is a bit much, but I didn't want to affect too much.
