### PR TITLE
Add some whitespace to resolution tree labels

### DIFF
--- a/bndtools.core/src/org/bndtools/core/ui/resource/R5LabelFormatter.java
+++ b/bndtools.core/src/org/bndtools/core/ui/resource/R5LabelFormatter.java
@@ -86,8 +86,8 @@ public class R5LabelFormatter {
             if (versionAttributeName != null) {
                 Object version = cap.getAttributes().get(versionAttributeName);
                 if (version != null) {
-                    label.append("," + versionAttributeName, StyledString.QUALIFIER_STYLER);
-                    label.append(version.toString(), UIConstants.BOLD_COUNTER_STYLER);
+                    label.append(", " + versionAttributeName, StyledString.QUALIFIER_STYLER);
+                    label.append(" " + version.toString(), UIConstants.BOLD_COUNTER_STYLER);
                 }
             }
         } else {
@@ -101,7 +101,7 @@ public class R5LabelFormatter {
             String key = entry.getKey();
             if (!key.equals(ns) && !key.equals(versionAttributeName)) {
                 if (!first)
-                    label.append(",", StyledString.QUALIFIER_STYLER);
+                    label.append(", ", StyledString.QUALIFIER_STYLER);
                 first = false;
                 label.append(key + "=", StyledString.QUALIFIER_STYLER);
                 label.append(entry.getValue() != null ? entry.getValue().toString() : "<null>", StyledString.QUALIFIER_STYLER);


### PR DESCRIPTION
Minor cosmetic change to the resolver UI to add some whitespace.  Top line is the old code, bottom line is the new code:

![image](https://cloud.githubusercontent.com/assets/114601/4164843/77252d7a-34fb-11e4-98cd-59afcfd71d96.png)
