### PR TITLE
Change new project classpath entries to not be exported

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -260,7 +260,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
                             rules.add(JavaCore.newAccessRule(new Path("**"), IAccessRule.K_NON_ACCESSIBLE));
                             accessRules = rules.toArray(new IAccessRule[rules.size()]);
                         }
-                        cpe = JavaCore.newProjectEntry(resource.getProject().getFullPath(), accessRules, false, extraAttrs, true);
+                        cpe = JavaCore.newProjectEntry(resource.getProject().getFullPath(), accessRules, false, extraAttrs, false);
                     } else {
                         IAccessRule[] accessRules = calculateRepoBundleAccessRules(c);
                         cpe = JavaCore.newLibraryEntry(p, null, null, accessRules, extraAttrs, false);


### PR DESCRIPTION
Not exporting the entry means that dependent projects will not have access to all classes available to the project. This makes Eclipse class resolution more consistent with the Bnd build path.

Signed-off-by: Humeniuk, Dave <david.humeniuk@udri.udayton.edu>