### PR TITLE
Set bnd_repourl gradle property into Workspace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ ext.bndWorkspace = Workspace.getWorkspace(rootDir, bnd_cnf)
 if (bndWorkspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }
+/* Set this property in the workspace. It may have been set on the command line with -P */
+bndWorkspace.setProperty('bnd_repourl', bnd_repourl)
 
 ext.cnf = rootProject.project(bnd_cnf)
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,6 +41,8 @@ def workspace = Workspace.getWorkspace(rootDir, bnd_cnf)
 if (workspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }
+/* Set this property in the workspace. It may have been set on the command line with -P */
+workspace.setProperty('bnd_repourl', bnd_repourl)
 
 /* Add cnf project to the graph */
 include bnd_cnf


### PR DESCRIPTION
This allows the repo url to be externally set in the CI build with the
gradle command line option -Pbnd_repourl=<url>.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
