### PR TITLE
Fix cnf clean

### DIFF
--- a/cnf/build.gradle
+++ b/cnf/build.gradle
@@ -5,6 +5,9 @@
 task('clean') {
   /* clean bnd cache */
   doLast {
-    project.delete(file('cache'))
+    file('cache').eachDir {
+      project.delete(it)
+    }
+    project.delete(fileTree('cache').exclude('.git*'))
   }
 }


### PR DESCRIPTION
When the change was made to cache the bnd repo in cnf/cache, the clean
of cnf/cache was not fixed to avoid deleting the cnf/cache directory.
This problem was discovered in
https://github.com/bndtools/bndtools/issues/945.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
