### PR TITLE
Enable workspace cnf variables in project .bnd and .bndrun -runrequires (and others)

### DIFF
--- a/bndtools.core/src/bndtools/wizards/bndfile/EnableSubBundlesOperation.java
+++ b/bndtools.core/src/bndtools/wizards/bndfile/EnableSubBundlesOperation.java
@@ -29,6 +29,7 @@ import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.properties.Document;
 import bndtools.Plugin;
+import bndtools.central.Central;
 
 public class EnableSubBundlesOperation implements IWorkspaceRunnable {
 
@@ -56,6 +57,7 @@ public class EnableSubBundlesOperation implements IWorkspaceRunnable {
         this.containerPath = containerPath;
     }
 
+    @Override
     public void run(final IProgressMonitor monitor) throws CoreException {
         IResource container = workspace.getRoot().findMember(containerPath);
 
@@ -63,8 +65,13 @@ public class EnableSubBundlesOperation implements IWorkspaceRunnable {
             throw newCoreException("Container path does not exist", null);
 
         // Create new project model
-        BndEditModel newBundleModel = new BndEditModel();
-
+        BndEditModel newBundleModel;
+        try {
+            newBundleModel = new BndEditModel(Central.getWorkspace());
+        } catch (Exception e) {
+            System.err.println("Unable to create BndEditModel with Workspace, defaulting to without Workspace");
+            newBundleModel = new BndEditModel();
+        }
         // Load project file and model
         IFile projectFile = container.getProject().getFile(Project.BNDFILE);
         BndEditModel projectModel;
@@ -76,7 +83,12 @@ public class EnableSubBundlesOperation implements IWorkspaceRunnable {
             } else {
                 projectDocument = new Document("");
             }
-            projectModel = new BndEditModel();
+            try {
+                projectModel = new BndEditModel(Central.getWorkspace());
+            } catch (Exception e) {
+                System.err.println("Unable to create BndEditModel with Workspace, defaulting to without Workspace");
+                projectModel = new BndEditModel();
+            }
             projectModel.loadFrom(projectDocument);
         } catch (IOException e) {
             throw new CoreException(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, e.getMessage(), e));

--- a/bndtools.core/src/bndtools/wizards/project/AbstractNewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/AbstractNewBndProjectWizard.java
@@ -48,6 +48,7 @@ import aQute.bnd.build.Project;
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.properties.Document;
 import bndtools.Plugin;
+import bndtools.central.Central;
 import bndtools.editor.model.BndProject;
 import bndtools.preferences.BndPreferences;
 
@@ -81,7 +82,12 @@ abstract class AbstractNewBndProjectWizard extends JavaProjectWizard {
             "static-method", "unused"
     })
     protected BndEditModel generateBndModel(IProgressMonitor monitor) {
-        return new BndEditModel();
+        try {
+            return new BndEditModel(Central.getWorkspace());
+        } catch (Exception e) {
+            logger.logError("Unable to create BndEditModel with Workspace, defaulting to without Workspace", e);
+            return new BndEditModel();
+        }
     }
 
     /**

--- a/bndtools.core/src/org/bndtools/core/ui/resource/R5LabelFormatter.java
+++ b/bndtools.core/src/org/bndtools/core/ui/resource/R5LabelFormatter.java
@@ -193,7 +193,18 @@ public class R5LabelFormatter {
 
         FilterParser fp = new FilterParser();
         if (filter == null) {
-            label.append(namespace + ": <no filter>", UIConstants.ERROR_STYLER);
+            if (namespace.contains("$")) {
+                Pattern pattern = Pattern.compile("\\{(.*?)\\}");
+                Matcher matcher = pattern.matcher(namespace);
+                label.append(namespace);
+                while (matcher.find()) {
+                    int begin = matcher.start(1);
+                    int end = matcher.end(1);
+                    label.setStyle(begin, end - begin, UIConstants.BOLD_STYLER);
+                }
+            } else {
+                label.append(namespace + ": <no filter>", UIConstants.ERROR_STYLER);
+            }
         } else {
             try {
                 Expression exp = fp.parse(filter);

--- a/bndtools.core/src/org/bndtools/core/ui/wizards/blueprint/BlueprintXmlFileWizard.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/blueprint/BlueprintXmlFileWizard.java
@@ -46,6 +46,7 @@ import aQute.bnd.build.model.clauses.HeaderClause;
 import aQute.bnd.osgi.Builder;
 import aQute.libg.glob.Glob;
 import bndtools.Plugin;
+import bndtools.central.Central;
 import bndtools.editor.BndEditor;
 import bndtools.editor.model.IDocumentWrapper;
 
@@ -195,7 +196,7 @@ public class BlueprintXmlFileWizard extends Wizard implements INewWizard {
         if (editor instanceof BndEditor) {
             editModel = ((BndEditor) editor).getEditModel();
         } else {
-            editModel = new BndEditModel();
+            editModel = new BndEditModel(Central.getWorkspace());
             doc = FileUtils.readFully(bndFile);
             editModel.loadFrom(new IDocumentWrapper(doc));
         }
@@ -256,6 +257,7 @@ public class BlueprintXmlFileWizard extends Wizard implements INewWizard {
         }
     }
 
+    @Override
     public void init(IWorkbench workbench, IStructuredSelection selection) {
         this.workbench = workbench;
         this.selection = selection;

--- a/bndtools.release/src/bndtools/release/ReleaseHelper.java
+++ b/bndtools.release/src/bndtools/release/ReleaseHelper.java
@@ -46,6 +46,7 @@ import aQute.bnd.properties.Document;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.version.Version;
 import aQute.service.reporter.Reporter;
+import bndtools.central.Central;
 import bndtools.release.api.IReleaseParticipant;
 import bndtools.release.api.ReleaseOption;
 import bndtools.release.api.IReleaseParticipant.Scope;
@@ -97,7 +98,15 @@ public class ReleaseHelper {
                 document = new Document(""); //$NON-NLS-1$
             }
 
-            final BndEditModel model = new BndEditModel();
+            final BndEditModel model;
+            BndEditModel model2;
+            try {
+                model2 = new BndEditModel(Central.getWorkspace());
+            } catch (Exception e) {
+                System.err.println("Unable to create BndEditModel with Workspace, defaulting to without Workspace");
+                model2 = new BndEditModel();
+            }
+            model = model2;
             model.loadFrom(document);
 
             String currentVersion = model.getBundleVersionString();
@@ -107,6 +116,7 @@ public class ReleaseHelper {
 
             final Document finalDoc = document;
             Runnable run = new Runnable() {
+                @Override
                 public void run() {
                     model.saveChangesTo(finalDoc);
 
@@ -230,6 +240,7 @@ public class ReleaseHelper {
         final List<Error> errors = context.getErrorHandler().getErrors();
         if (errors.size() > 0) {
             Runnable runnable = new Runnable() {
+                @Override
                 public void run() {
                     Shell shell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
                     ErrorDialog error = new ErrorDialog(shell, name, errors);


### PR DESCRIPTION
This change goes along with the companion bnd change. It enables
Workspace properties to be used in BndEditModel.

It also includes a R5LabelFormatter to show the variable on a runbnd
editor.

Signed-off-by: Carter Smithhart <carter.smithhart@gmail.com>