### PR TITLE
Buildpath needs to be reevaluated when jars change out from under.

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/NewBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/NewBuilder.java
@@ -159,6 +159,13 @@ public class NewBuilder extends IncrementalProjectBuilder {
                 return dependsOn;
             }
 
+            //[cs] This should already reset classpaths when they need to be.
+            if (BndContainerInitializer.resetClasspaths(model, myProject, classpathErrors)) {
+                log(LOG_BASIC, "classpaths were changed");
+            } else {
+                log(LOG_FULL, "classpaths did not need to change");
+            }
+            
             // CASE 2: local Bnd file changed, or Eclipse asks for full build
             boolean localChange = false;
             if (kind == FULL_BUILD) {


### PR DESCRIPTION
For instance, this fixes a glitch when a locally installed maven
artifact is added to maven local repo while eclipse is running.
The buildpath needs to be reevaluated.

Signed-off-by: Carter Smithhart carter.smithhart@gmail.com
