### PR TITLE
Setup cwd on project launcher to project base

### DIFF
--- a/bndtools.core/src/bndtools/wizards/bndfile/ExecutableJarExportWizard.java
+++ b/bndtools.core/src/bndtools/wizards/bndfile/ExecutableJarExportWizard.java
@@ -83,6 +83,7 @@ public class ExecutableJarExportWizard extends Wizard implements IRunDescription
         MultiStatus status = new MultiStatus(Plugin.PLUGIN_ID, 0, "Errors occurred during exporting.", null);
         try {
             ProjectLauncher launcher = bndProject.getProjectLauncher();
+            launcher.setCwd(bndProject.getBase());
             Jar jar = launcher.executable();
             jar.write(jarPath);
         } catch (Exception e) {


### PR DESCRIPTION
While working through enRoute tutorials, when trying to create the executable jar [on this page](http://enroute.osgi.org/tutorial_base/700-deploy.html) I noticed that my Eclipse installation would hang and UI would be unresponsive and CPU go to 100%.

I spun up a yourkit profiler and saw this: 
![workspace 1_072](https://cloud.githubusercontent.com/assets/595221/5530869/1da85e7e-8a60-11e4-86d9-60df336afd64.png)

Here is a thread dump:
![workspace 1_073](https://cloud.githubusercontent.com/assets/595221/5530912/accf9b30-8a60-11e4-9ff3-defd57a8e783.png)

As you can see the main UI thread is pegged trying to report errors.  I debugged through the code and the reason for all the error strings (nearly 1GB of them) is that the PreProcessResource class is executing on all of the resources in my local eclipse installation.  `/home/user/eclipse/configuration/*.*`

The reason it is looping through my "configuration" folder is that in my "executable jar" project, the application project has a "configuration" folder that is used for the service factory configuration.  So since it happens to have the same name as a folder in my Eclipse installation, the bnd Builder is recursing through everything there in my Eclipse installation config dir, instead of in my actual application project configuration directory.  This is blowing up memory as it is actually processing many different .class files that show up in the exploded osgi work folders, such as `./eclipse/configuration/org.eclipse.osgi/358/0/.cp/org/eclipse/jdt/internal/junit/runner/ITestIdentifier.class`

So in this fix I have proposed, I simply tell the project launcher to setup the cwd as the same directory as the project for which the executable jar is being exported.

**Note**: this requires another change on the bnd side as well to make sure the projectLauncher pays attention to the "cwd" parameter and sets the Builder.setBase() accordingly.
