### PR TITLE
Use property to control transitive dependencies in eclipse.

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -263,7 +263,8 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
                         cpe = JavaCore.newProjectEntry(resource.getProject().getFullPath(), accessRules, false, extraAttrs, true);
                     } else {
                         IAccessRule[] accessRules = calculateRepoBundleAccessRules(c);
-                        cpe = JavaCore.newLibraryEntry(p, null, null, accessRules, extraAttrs, false);
+                        boolean transitive = Boolean.parseBoolean(model.getProperty(aQute.bnd.osgi.Constants.TRANSITIVE, "false"));
+                        cpe = JavaCore.newLibraryEntry(p, null, null, accessRules, extraAttrs, transitive);
                     }
                     result.add(cpe);
                 }


### PR DESCRIPTION
Someone could choose to workaround bndtools bug #420, where
transitive dependencies cause some issues inside eclipse.

This fix makes jar file references allow transitive dependencies.

Signed-off-by: Carter Smithhart <carter.smithhart@gmail.com>