### PR TITLE
[launching] The run configuration clean overrode -runkeep

### DIFF
--- a/bndtools.core/src/bndtools/launch/OSGiRunLaunchDelegate.java
+++ b/bndtools.core/src/bndtools/launch/OSGiRunLaunchDelegate.java
@@ -43,7 +43,6 @@ import aQute.bnd.build.ProjectLauncher;
 import aQute.bnd.build.ProjectLauncher.NotificationListener;
 import aQute.bnd.build.ProjectLauncher.NotificationType;
 import aQute.bnd.osgi.Jar;
-import aQute.lib.io.IO;
 import bndtools.Plugin;
 import bndtools.central.Central;
 import bndtools.launch.util.LaunchUtils;
@@ -179,18 +178,17 @@ public class OSGiRunLaunchDelegate extends AbstractOSGiLaunchDelegate {
         super.launch(configuration, mode, launch, progress.newChild(1, SubMonitor.SUPPRESS_NONE));
     }
 
+    /**
+     * This was first always overriding -runkeep. Now it can only override it if -runkeep is set to false. However, I
+     * think this option should go away in bndtools. Anyway, removed the actual clearing since this was already done in
+     * the launcher.
+     */
     private void configureLauncher(ILaunchConfiguration configuration) throws CoreException {
-        boolean clean = configuration.getAttribute(LaunchConstants.ATTR_CLEAN, LaunchConstants.DEFAULT_CLEAN);
+        if (bndLauncher.isKeep() == false) {
+            boolean clean = configuration.getAttribute(LaunchConstants.ATTR_CLEAN, LaunchConstants.DEFAULT_CLEAN);
 
-        if (clean) {
-            File storage = bndLauncher.getStorageDir();
-            if (storage.exists()) {
-                IO.delete(storage);
-            }
+            bndLauncher.setKeep(!clean);
         }
-
-        bndLauncher.setKeep(!clean);
-
         enableTraceOptionIfSetOnConfiguration(configuration, bndLauncher);
     }
 


### PR DESCRIPTION
The  Run configuration specifies a clean option. This caused the setting of the -runkeep to be discarded. Will now only look at it when the -runkeep is off. Also removed the cleaning of the directory since this happens in the launcher.

Example of doing things in two places. This kind of stuff must only be done in bnd!
