### PR TITLE
Reducing number of RefreshFileJob threads

### DIFF
--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -434,6 +434,17 @@ public class Central implements IStartupParticipant {
         return result;
     }
 
+    public static IPath toPathMustBeInEclipseWorkspace(File file) throws Exception {
+        IPath result = null;
+        File absolute = file.getCanonicalFile();
+        IWorkspaceRoot wsroot = ResourcesPlugin.getWorkspace().getRoot();
+        IFile[] candidates = wsroot.findFilesForLocationURI(absolute.toURI());
+        if (candidates != null && candidates.length > 0) {
+            result = candidates[0].getFullPath();
+        }
+        return result;
+    }
+
     public static void refresh(IPath path) {
         try {
             IResource r = ResourcesPlugin.getWorkspace().getRoot().findMember(path);


### PR DESCRIPTION
Improves performance when importing a lot of projects
and when refreshing a lot of projects.