### PR TITLE
Created a set of new access rules for eclipse

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -109,3 +109,8 @@ Bundle-License:           http://www.eclipse.org/legal/epl-v10.html
 -diffignore: Git-Descriptor,Git-SHA
 
 -removeheaders: Include-Resource, Private-Package
+
+# bndtools pull request #1003 and #999
+# we're vetting the new access rules for a while before adjusting
+# the fundamentals of bndtools out from under our users. heh.
+eclipse.newaccessrules: true


### PR DESCRIPTION
These are not turned on by default, since I wanted to slow roll the incorporation
of something so fundamental to bndtools.

To enable, add a project or global variable:
eclipse.newaccessrules: true

You can also debug access rules with
eclipse.debug: true

The new rules add library classpath entries instead of project classpath entries
except for version=project references, which still add project references. All
transitive dependencies are turned off with the new rules too. This should be
closer to the bnd command line build handling of jars on the classpath during
a build.

These new access rules should address several transitive dependency issues that
I've encountered and I've seen written up as issues.

Signed-off-by: Carter Smithhart <carter.smithhart@gmail.com>