### PR TITLE
Allow mulitple git repos in one eclipse workspace

### DIFF
--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -151,42 +151,32 @@ public class Central implements IStartupParticipant {
                             System.out.println("Cannot convert resource to file: " + delta.getResource());
                         } else {
                             File file = location.toFile();
-                            File parent = file.getParentFile();
-                            boolean parentIsWorkspace = parent.equals(getWorkspace().getBase());
 
-                            // file
-                            // /development/osgi/svn/build/org.osgi.test.cases.distribution/bnd.bnd
-                            // parent
-                            // /development/osgi/svn/build/org.osgi.test.cases.distribution
-                            // workspace /development/amf/workspaces/osgi
-                            // false
-
-                            if (parentIsWorkspace) {
-                                // We now are on project level, we do not go
-                                // deeper
-                                // because projects/workspaces should check for
-                                // any
-                                // changes.
-                                // We are careful not to create unnecessary
-                                // projects
-                                // here.
-                                if (file.getName().equals(Workspace.CNFDIR)) {
-                                    if (workspace.refresh()) {
-                                        changed.addAll(workspace.getCurrentProjects());
-                                    }
-                                    return false;
-                                }
-                                if (workspace.isPresent(file.getName())) {
-                                    Project project = workspace.getProject(file.getName());
-                                    changed.add(project);
-                                } else {
-                                    // Project not created yet, so we
-                                    // have
-                                    // no cached results
-
+                            // We now are on project level, we do not go
+                            // deeper
+                            // because projects/workspaces should check for
+                            // any
+                            // changes.
+                            // We are careful not to create unnecessary
+                            // projects
+                            // here.
+                            if (file.getName().equals(Workspace.CNFDIR)) {
+                                if (workspace.refresh()) {
+                                    changed.addAll(workspace.getCurrentProjects());
                                 }
                                 return false;
                             }
+                            if (workspace.isPresent(file)) {
+                                Project project = workspace.getProjectByFile(file);
+                                changed.add(project);
+                            } else {
+                                // Project not created yet, so we
+                                // have
+                                // no cached results
+
+                            }
+                            return false;
+
                         }
                         return true;
                     } catch (Exception e) {
@@ -578,7 +568,7 @@ public class Central implements IStartupParticipant {
         assert projectDirAbsolute.isDirectory();
 
         Workspace ws = getWorkspace();
-        return ws.getProject(projectDir.getName());
+        return ws.getProjectByFile(projectDir);
     }
 
     public static Project getProject(IProject p) throws Exception {

--- a/bndtools.core/src/bndtools/launch/util/LaunchUtils.java
+++ b/bndtools.core/src/bndtools/launch/util/LaunchUtils.java
@@ -40,7 +40,7 @@ public final class LaunchUtils {
         IProject project = launchResource.getProject();
         Project bnd;
         try {
-            bnd = Central.getWorkspace().getProject(project.getName());
+            bnd = Central.getProject(project);
         } catch (Exception e) {
             bnd = null;
         }

--- a/bndtools.release/src/bndtools/release/ReleaseAction.java
+++ b/bndtools.release/src/bndtools/release/ReleaseAction.java
@@ -32,95 +32,98 @@ import bndtools.central.Central;
 import bndtools.release.nl.Messages;
 
 public class ReleaseAction implements IObjectActionDelegate {
-//	@SuppressWarnings("unused")
-//	private IWorkbenchPart targetPart;
+    //	@SuppressWarnings("unused")
+    //	private IWorkbenchPart targetPart;
 
-	private Map<Project, List<File>> bndFiles;
+    private Map<Project,List<File>> bndFiles;
 
-	public void run(IAction action) {
+    @Override
+    public void run(IAction action) {
 
-		if (bndFiles != null) {
+        if (bndFiles != null) {
             if (ReleaseHelper.getReleaseRepositories().length == 0) {
                 Activator.message(Messages.noReleaseRepos);
                 return;
             }
 
-			if (!PlatformUI.getWorkbench().saveAllEditors(true)) {
-				return;
-			}
+            if (!PlatformUI.getWorkbench().saveAllEditors(true)) {
+                return;
+            }
 
-			for (Map.Entry<Project, List<File>> me : bndFiles.entrySet()) {
+            for (Map.Entry<Project,List<File>> me : bndFiles.entrySet()) {
 
-				Project project;
-				try {
-					project = me.getKey();
-				} catch (Exception e) {
-					throw new RuntimeException(e);
-				}
-				ReleaseDialogJob job;
-				if (isBndBndSelected(me.getValue())) {
-					job = new ReleaseDialogJob(project, null);
-				} else {
-					job = new ReleaseDialogJob(project, me.getValue());
-				}
-				job.schedule();
-			}
-		}
-	}
+                Project project;
+                try {
+                    project = me.getKey();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                ReleaseDialogJob job;
+                if (isBndBndSelected(me.getValue())) {
+                    job = new ReleaseDialogJob(project, null);
+                } else {
+                    job = new ReleaseDialogJob(project, me.getValue());
+                }
+                job.schedule();
+            }
+        }
+    }
 
-	private static boolean isBndBndSelected(List<File> files) {
-		for (File file : files) {
-			if (Project.BNDFILE.equals(file.getName())) {
-				return true;
-			}
-		}
-		return false;
-	}
+    private static boolean isBndBndSelected(List<File> files) {
+        for (File file : files) {
+            if (Project.BNDFILE.equals(file.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	/**
-	 * @see IActionDelegate#selectionChanged(IAction, ISelection)
-	 */
-	public void selectionChanged(IAction action, ISelection selection) {
-		IFile[] locations = getLocations(selection);
-		bndFiles = new LinkedHashMap<Project, List<File>>();
-		for (IFile iFile : locations) {
-			File file = iFile.getLocation().toFile();
-			Project project;
-			try {
-			    IProject iProject = iFile.getProject();
-				project = Central.getWorkspace().getProject(iProject.getName());
-				// .bnd files exists in cnf that are unreleasable
-				if (project == null || project.isCnf()) {
-				    continue;
-				}
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-			List<File> projectFiles = bndFiles.get(project);
-			if (projectFiles == null) {
-				projectFiles = new ArrayList<File>();
-				bndFiles.put(project, projectFiles);
-			}
-			projectFiles.add(file);
-		}
-	}
+    /**
+     * @see IActionDelegate#selectionChanged(IAction, ISelection)
+     */
+    @Override
+    public void selectionChanged(IAction action, ISelection selection) {
+        IFile[] locations = getLocations(selection);
+        bndFiles = new LinkedHashMap<Project,List<File>>();
+        for (IFile iFile : locations) {
+            File file = iFile.getLocation().toFile();
+            Project project;
+            try {
+                IProject iProject = iFile.getProject();
+                project = Central.getProject(iProject);
+                // .bnd files exists in cnf that are unreleasable
+                if (project == null || project.isCnf()) {
+                    continue;
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            List<File> projectFiles = bndFiles.get(project);
+            if (projectFiles == null) {
+                projectFiles = new ArrayList<File>();
+                bndFiles.put(project, projectFiles);
+            }
+            projectFiles.add(file);
+        }
+    }
 
-	static
-	IFile[] getLocations(ISelection selection) {
-		if (selection != null && (selection instanceof StructuredSelection)) {
-			StructuredSelection ss = (StructuredSelection) selection;
-			IFile[] result = new IFile[ss.size()];
-			int n = 0;
-			for (@SuppressWarnings("unchecked") Iterator<IFile> i = ss.iterator(); i.hasNext();) {
-				result[n++] = i.next();
-			}
-			return result;
-		}
-		return null;
-	}
+    static IFile[] getLocations(ISelection selection) {
+        if (selection != null && (selection instanceof StructuredSelection)) {
+            StructuredSelection ss = (StructuredSelection) selection;
+            IFile[] result = new IFile[ss.size()];
+            int n = 0;
+            for (@SuppressWarnings("unchecked")
+            Iterator<IFile> i = ss.iterator(); i.hasNext();) {
+                result[n++] = i.next();
+            }
+            return result;
+        }
+        return null;
+    }
 
-	public void setActivePart(IAction action, IWorkbenchPart targetPart) {
-		// this.targetPart = targetPart;
-	}
+    @Override
+    public void setActivePart(IAction action, IWorkbenchPart targetPart) {
+        // this.targetPart = targetPart;
+    }
 
 }


### PR DESCRIPTION
This change along with https://github.com/bndtools/bnd/pull/704
allows multiple git repos in the eclipse workspace. It does this by passing in the file path of each project instead of just the name. That way bnd does not have to assume that the project is relative to the cnf folder. The refresh task was changed to ask bnd if the file path was in one of the projects since all the projects are no longer in the same root workspace.

LaunchUtils.java, ReleaseAction.java were changed to use the getProject helper for consistency.

Signed-off-by: Dave Smith <dave.smith@candata.com>