### PR TITLE
Adjust newaccessrules classpath entries for Container.TYPE.PROJECT

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -290,12 +290,19 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
                         if (c.getType() == Container.TYPE.PROJECT && c.getFile().isDirectory()) {
                             IResource resource = ResourcesPlugin.getWorkspace().getRoot().getFile(p);
                             cpe = JavaCore.newProjectEntry(resource.getProject().getFullPath(), null, false, extraAttrs, false);
-                        } else if (c.getType() == Container.TYPE.PROJECT) {
+                            result.add(cpe);
                             cpe = JavaCore.newLibraryEntry(p, null, null, null, extraAttrs, false);
+                            result.add(cpe);
+                        } else if (c.getType() == Container.TYPE.PROJECT) {
+                            IResource resource = ResourcesPlugin.getWorkspace().getRoot().getFile(p);
+                            cpe = JavaCore.newProjectEntry(resource.getProject().getFullPath(), null, false, extraAttrs, false);
+                            result.add(cpe);
+                            cpe = JavaCore.newLibraryEntry(p, null, null, null, extraAttrs, false);
+                            result.add(cpe);
                         } else {
                             cpe = JavaCore.newLibraryEntry(p, null, null, null, extraAttrs, false);
+                            result.add(cpe);
                         }
-                        result.add(cpe);
                     }
                 }
             } else {


### PR DESCRIPTION
Make a library and a project entry for each buildpath entry that resolves
to an eclipse project.

This seems to address the source lookup and source refactoring
problems discussed in #1005. And it seems to have all of the benefits
of what the new access rules are bringing.

More bake time now...

Signed-off-by: Carter Smithhart <carter.smithhart@gmail.com>