### PR TITLE
build: Clean up bnd files

### DIFF
--- a/bndtools.bndplugins/bnd.bnd
+++ b/bndtools.bndplugins/bnd.bnd
@@ -4,10 +4,11 @@
 	ee.j2se;version=${javac.ee},\
 	${bndlib},\
 	${aQute-repository},\
-	aQute.libg;version="[3,4)",\
 	com.jcraft.jsch,\
 	org.eclipse.jgit,\
-	org.osgi.impl.bundle.bindex,\
+	org.osgi.impl.bundle.bindex
+	
+-testpath: \
 	${junit}
 
 -sub: *.bnd

--- a/bndtools.builder/bnd.bnd
+++ b/bndtools.builder/bnd.bnd
@@ -21,10 +21,10 @@
 	org.eclipse.jdt.core,\
 	org.eclipse.jdt.launching,\
 	org.eclipse.jdt.ui,\
-	org.eclipse.swt.cocoa.macosx.x86_64,\
+	org.eclipse.swt.cocoa.macosx.x86_64;packages=**,\
 	org.eclipse.swt,\
 	bndtools.api;version=latest,\
-	bndtools.utils;version=project,\
+	bndtools.utils;version=project;packages=**,\
 	bndtools.core;version=snapshot
 
 # Headers

--- a/bndtools.core/bnd.bnd
+++ b/bndtools.core/bnd.bnd
@@ -53,7 +53,7 @@ eclipse.deps: \
 	org.eclipse.jface.text,\
 	org.eclipse.core.resources,\
 	org.eclipse.equinox.common,\
-	org.eclipse.swt.cocoa.macosx.x86_64,\
+	org.eclipse.swt.cocoa.macosx.x86_64;packages=**,\
 	org.eclipse.swt,\
 	org.eclipse.text,\
 	org.eclipse.ui.workbench,\
@@ -99,6 +99,8 @@ eclipse.deps: \
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
 	org.bndtools.versioncontrol.ignores.manager;version=latest,\
-	bndtools.utils;version=project,\
-	bndtools.repository.base;version=latest,\
-	junit.osgi; version=@3.8
+	bndtools.utils;version=project;packages=**,\
+	bndtools.repository.base;version=latest
+	
+-testpath: \
+	${junit3}

--- a/bndtools.jareditor/bnd.bnd
+++ b/bndtools.jareditor/bnd.bnd
@@ -15,7 +15,7 @@ Include-Resource: resources
 	org.eclipse.ui.ide,\
 	org.eclipse.ui,\
 	org.eclipse.swt,\
-	org.eclipse.swt.cocoa.macosx.x86_64,\
+	org.eclipse.swt.cocoa.macosx.x86_64;packages=**,\
 	org.eclipse.jface,\
 	org.eclipse.ui.workbench,\
 	org.eclipse.ui.workbench.texteditor,\

--- a/bndtools.release/bnd.bnd
+++ b/bndtools.release/bnd.bnd
@@ -15,7 +15,7 @@ Private-Package: \
 	bndtools.release,\
 	bndtools.release.nl,\
 	bndtools.release.ui,\
-	org.bndtools.utils.swt
+	org.bndtools.utils.swt;-split-package:=first
 
 Conditional-Package: aQute.lib.*,aQute.libg.*
 
@@ -26,6 +26,8 @@ Include-Resource: 	plugin.xml=_plugin.xml,\
 	ee.j2se;version=${javac.ee},\
 	osgi.core;version=${osgi.core.version},\
 	osgi.cmpn;version=${osgi.cmpn.version},\
+	${bndlib},\
+	bndtools.utils;version=project;packages=**,\
 	bndtools.core;version=latest, \
 	org.eclipse.core.runtime,\
 	org.eclipse.core.contenttype,\
@@ -33,7 +35,7 @@ Include-Resource: 	plugin.xml=_plugin.xml,\
 	org.eclipse.jface.text,\
 	org.eclipse.core.resources,\
 	org.eclipse.equinox.common,\
-	org.eclipse.swt.cocoa.macosx.x86_64,\
+	org.eclipse.swt.cocoa.macosx.x86_64;packages=**,\
 	org.eclipse.swt,\
 	org.eclipse.text,\
 	org.eclipse.ui.workbench,\
@@ -55,8 +57,9 @@ Include-Resource: 	plugin.xml=_plugin.xml,\
 	org.eclipse.jdt.junit,\
 	org.eclipse.team.core,\
 	org.eclipse.core.filesystem, \
-	org.eclipse.equinox.preferences, \
-	${bndlib},\
+	org.eclipse.equinox.preferences
+	
+-testpath: \
 	${junit}
 
 Export-Package: bndtools.release.api

--- a/bndtools.utils/bnd.bnd
+++ b/bndtools.utils/bnd.bnd
@@ -12,13 +12,15 @@
     org.eclipse.core.resources, \
     org.eclipse.core.jobs, \
     org.eclipse.jface, \
-    org.eclipse.swt.cocoa.macosx.x86_64, \
+    org.eclipse.swt.cocoa.macosx.x86_64;packages=**, \
     org.eclipse.swt, \
     org.eclipse.ui.ide, \
     org.eclipse.ui.workbench, \
     org.eclipse.jdt.core, \
     org.eclipse.text, \
-    bndtools.api; version=latest, \
+    bndtools.api; version=latest
+    
+-testpath: \
     ${junit}
 
 # No exports. This is bundle is not intended for runtime use.

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -79,7 +79,8 @@ base-version-qualifier:   DEV
 # On advice of Peter we use an up-to-major version range
 bnd-version-base:         3.0.0
 bnd-version-ceiling:      4.0.0
-bndlib:                   biz.aQute.bndlib;version='[${bnd-version-base},${bnd-version-ceiling})'
+bndlib:                   aQute.libg;version='[${bnd-version-base},${bnd-version-ceiling})', \
+                          biz.aQute.bndlib;version='[${bnd-version-base},${bnd-version-ceiling})'
 
 # Version of the repository plugin to use consistently throughout the build
 # NB. this must be specified as full M.m.u version (but no qualifier)

--- a/org.bndtools.headless.build.manager/bnd.bnd
+++ b/org.bndtools.headless.build.manager/bnd.bnd
@@ -1,7 +1,9 @@
 -buildpath:  \
     ee.j2se;version='[1.6,1.7)',\
     bndtools.api;version=latest,\
-	biz.aQute.bnd.annotation,\
+	biz.aQute.bnd.annotation
+	
+-testpath: \
 	${junit}
 
 # we really need this, otherwise Eclipse will not start our bundles

--- a/org.bndtools.headless.build.plugin.ant/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.ant/bnd.bnd
@@ -3,10 +3,13 @@
 	osgi.core;version=${osgi.core.version},\
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
-	bndtools.utils;version=project,\
+	bndtools.utils;version=project;packages=**,\
 	biz.aQute.bnd.annotation,\
-	${bndlib},\
+	${bndlib}
+
+-testpath: \
 	${junit}
+
 -includeresource: \
 	templates=resources/templates/unprocessed,\
 	templates/cnf/plugins/biz.aQute.bnd/biz.aQute.bnd.jar=${repo;biz.aQute.bnd;${bnd-version-base}}

--- a/org.bndtools.headless.build.plugin.gradle/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.gradle/bnd.bnd
@@ -4,7 +4,7 @@
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
 	org.bndtools.versioncontrol.ignores.manager;version=latest,\
-	bndtools.utils;version=project,\
+	bndtools.utils;version=project;packages=**,\
 	biz.aQute.bnd.annotation,\
 	${bndlib},\
 	${junit}

--- a/org.bndtools.versioncontrol.ignores.manager/bnd.bnd
+++ b/org.bndtools.versioncontrol.ignores.manager/bnd.bnd
@@ -1,7 +1,9 @@
 -buildpath:  \
     ee.j2se;version='[1.6,1.7)',\
     bndtools.api;version=latest,\
-	biz.aQute.bnd.annotation,\
+	biz.aQute.bnd.annotation
+
+-testpath: \
 	${junit}
 
 # we really need this, otherwise Eclipse will not start our bundles

--- a/org.bndtools.versioncontrol.ignores.plugin.git/bnd.bnd
+++ b/org.bndtools.versioncontrol.ignores.plugin.git/bnd.bnd
@@ -2,7 +2,9 @@
 	ee.j2se;version=${javac.ee},\
 	bndtools.api;version=latest,\
 	org.bndtools.versioncontrol.ignores.manager;version=latest,\
-	biz.aQute.bnd.annotation,\
+	biz.aQute.bnd.annotation
+
+-testpath: \
 	${junit}
 
 # we really need this, otherwise Eclipse will not start our bundles


### PR DESCRIPTION
The new classpath container identified a number of issues on the bnd
files for a number of projects.

- Use aQute.libg directly instead of relying on it being in bndlib
- Move junit to -testpath
- Add "packages=**" to swt fragment and bndtools.utils entries

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>