### PR TITLE
Dont force classpath container creation

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -252,7 +252,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
      */
     private boolean resetClasspathContainer(IProject myProject, List<String> errors) throws CoreException {
         if (BndContainerInitializer.resetClasspaths(model, myProject, errors)) {
-            buildLog.basic("classpaths were changed " + errors);
+            buildLog.basic("classpaths were changed %s", errors);
             return true;
         }
         return false;
@@ -269,7 +269,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
                 return false;
             projectDescription.setDynamicReferences(newer);
             getProject().setDescription(projectDescription, null);
-            buildLog.full("Changed the build order to " + Arrays.toString(newer));
+            buildLog.full("Changed the build order to %s", Arrays.toString(newer));
 
         } catch (Exception e) {
             logger.logError("Failed to set build order", e);

--- a/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
+++ b/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
@@ -9,12 +9,17 @@ public class BuildLogger {
     public static final int LOG_BASIC = 1;
     public static final int LOG_NONE = 0;
     private final int level;
-    long start = System.currentTimeMillis();
-    Formatter formatter = new Formatter();
-    boolean used = false;
+    private final long start = System.currentTimeMillis();
+    private final StringBuilder sb = new StringBuilder();
+    private final Formatter formatter = new Formatter(sb);
+    private boolean used = false;
 
     public BuildLogger(int level) {
         this.level = level;
+    }
+
+    public void basic(String string) {
+        basic(string, (Object[]) null);
     }
 
     public void basic(String string, Object... args) {
@@ -22,6 +27,10 @@ public class BuildLogger {
             return;
 
         message(string, args);
+    }
+
+    public void full(String string) {
+        full(string, (Object[]) null);
     }
 
     public void full(String string, Object... args) {
@@ -37,28 +46,31 @@ public class BuildLogger {
 
     @Override
     public String toString() {
-        return formatter.toString();
+        return sb.toString();
     }
 
-    private void message(String string, Object... args) {
+    private void message(String string, Object[] args) {
         used = true;
-        formatter.format(string, args);
-        formatter.format("\n");
+        if (args == null) {
+            sb.append(string);
+        } else {
+            formatter.format(string, args);
+        }
+        sb.append('\n');
     }
 
     public String toString(Project model, int files) {
         long end = System.currentTimeMillis();
         full("Duration %.2f sec", (end - start) / 1000f);
 
-        String top = "BUILD " + model;
+        StringBuilder top = new StringBuilder();
+        Formatter topper = new Formatter(top);
         if (files > 0)
-            top += " " + files + " file" + (files == 1 ? " was" : "s were") + " built";
+            topper.format("BUILD %s %d file%s built", model.getName(), files, files > 1 ? "s were" : " was");
         else
-            top += " no build";
-        top += "\n";
+            topper.format("BUILD %s no build", model.getName());
+        topper.close();
 
-        return top + formatter;
-
+        return top.append('\n').append(sb).toString();
     }
-
 }

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -38,6 +38,7 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 
 import aQute.bnd.build.CircularDependencyException;
 import aQute.bnd.build.Container;
@@ -102,7 +103,11 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 
     public static boolean resetClasspaths(Project model, IProject project, Collection<String> errors) throws CoreException {
         IJavaProject javaProject = JavaCore.create(project);
-        IClasspathContainer container = JavaCore.getClasspathContainer(BndtoolsConstants.BND_CLASSPATH_ID, javaProject);
+        IClasspathContainer container = JavaModelManager.getJavaModelManager().containerGet(javaProject, BndtoolsConstants.BND_CLASSPATH_ID);
+        if (container == null) {
+            return false; // project does not have a BndContainer
+        }
+        container = JavaCore.getClasspathContainer(BndtoolsConstants.BND_CLASSPATH_ID, javaProject);
         List<IClasspathEntry> currentClasspath = Arrays.asList(container.getClasspathEntries());
 
         List<IClasspathEntry> newClasspath = calculateProjectClasspath(model, project, errors);


### PR DESCRIPTION
A project might have a bnd builder but not use the bnd classpath
container. When checking if the classpath has changed during incremental
build, we don't want to force the creation of a bnd classpath
container if the project does not already have one.