### PR TITLE
classpath: bnd project may not be in eclipse workspace

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -150,8 +150,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
     public void modelChanged(Project model) throws Exception {
         IJavaProject javaProject = Central.getJavaProject(model);
         if (javaProject == null) {
-            logger.logError("Help! No IJavaProject for " + model, null);
-            return;
+            return; // bnd project is not loaded in the workspace
         }
         requestClasspathContainerUpdate(BndtoolsConstants.BND_CLASSPATH_ID, javaProject, null);
     }


### PR DESCRIPTION
A project in the bnd workspace may not be in the eclipse workspace.
Sometimes a project (which is not use by projects loaded in the eclipse
workspace) may not be loaded into the eclipse workspace.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>