### PR TITLE
install: Fix p2 install failure

### DIFF
--- a/org.bndtools.headless.build.plugin.ant/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.ant/bnd.bnd
@@ -19,7 +19,8 @@ Bundle-ActivationPolicy: lazy
 
 Conditional-Package: \
 	org.bndtools.utils.copy.bundleresource,\
-	aQute.lib.io
+	aQute.lib.*;-split-package:=merge-first, \
+	aQute.libg.*;-split-package:=merge-first
 Private-Package: \
 	org.bndtools.headless.build.plugin.ant
 Service-Component: *

--- a/org.bndtools.headless.build.plugin.gradle/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.gradle/bnd.bnd
@@ -17,7 +17,8 @@ Bundle-ActivationPolicy: lazy
 
 Conditional-Package: \
 	org.bndtools.utils.copy.bundleresource,\
-	aQute.lib.io
+	aQute.lib.*;-split-package:=merge-first, \
+	aQute.libg.*;-split-package:=merge-first
 Private-Package: \
 	org.bndtools.headless.build.plugin.gradle
 Service-Component: *


### PR DESCRIPTION
Projects imported an aQute.lib* package that should have been included.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>