### PR TITLE
Reorganize classpath container implementation to avoid deadlocks in calling bnd code

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
@@ -4,34 +4,38 @@ import org.bndtools.api.BndtoolsConstants;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
-import org.eclipse.jdt.core.IJavaProject;
-
 
 public class BndContainer implements IClasspathContainer {
-
-    final IJavaProject javaProject;
-    final IClasspathEntry[] entries;
+    private final IClasspathEntry[] entries;
     private final String description;
 
-    public BndContainer(IJavaProject javaProject, IClasspathEntry[] entries, String description) {
-        this.javaProject = javaProject;
+    public BndContainer(IClasspathEntry[] entries, String description) {
         this.entries = entries;
         this.description = description;
     }
 
+    @Override
     public IClasspathEntry[] getClasspathEntries() {
         return entries;
     }
 
+    @Override
     public String getDescription() {
-        return description != null ? description : "Bnd Bundle Path";
+        return description;
     }
 
+    @Override
     public int getKind() {
         return IClasspathContainer.K_APPLICATION;
     }
 
+    @Override
     public IPath getPath() {
         return BndtoolsConstants.BND_CLASSPATH_ID;
+    }
+
+    @Override
+    public String toString() {
+        return getDescription();
     }
 }

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -53,35 +53,37 @@ import bndtools.central.RefreshFileJob;
 import bndtools.preferences.BndPreferences;
 
 /**
- * A bnd container reads the bnd.bnd file in the project directory and use the information in there to establish the
- * classpath. The classpath is defined by the -build-env instruction. This instruction contains a list of bsn's that are
- * searched in the available repositories and returned as File objects. This initializer establishes the link between
- * the container object and the BndModel. The container object is just a delegator because for some unknown reasons, you
- * can only update the container (refresh the contents) when you give it a new object ;-( Because this plugin uses the
- * Bnd Builder in different places, the Bnd Model is centralized and available from the Activator.
+ * ClasspathContainerInitializer for the aQute.bnd.classpath.container name.
+ * <p>
+ * Used in the .classpath file of bnd project to couple the bnd -buildpath into the Eclipse IDE.
  */
 public class BndContainerInitializer extends ClasspathContainerInitializer implements ModelListener {
-    private static final ILogger logger = Logger.getLogger(BndContainerInitializer.class);
-    private static final IClasspathEntry[] EMPTY_ENTRIES = new IClasspathEntry[0];
-    private static final IAccessRule DISCOURAGED = JavaCore.newAccessRule(new Path("**"), IAccessRule.K_DISCOURAGED);
+    static final ILogger logger = Logger.getLogger(BndContainerInitializer.class);
+    static final IClasspathEntry[] EMPTY_ENTRIES = new IClasspathEntry[0];
+    static final IAccessRule DISCOURAGED = JavaCore.newAccessRule(new Path("**"), IAccessRule.K_DISCOURAGED);
+    static final Pattern packagePattern = Pattern.compile("(?<=^|\\.)\\*(?=\\.|$)|\\.");
 
     public BndContainerInitializer() {
+        super();
         Central.getInstance().addModelListener(this);
     }
 
     @Override
-    public void initialize(IPath containerPath, final IJavaProject javaProject) throws CoreException {
-        final List<String> errors = new ArrayList<String>();
-        calculateAndUpdateClasspathEntries(javaProject, errors);
+    public void initialize(IPath containerPath, IJavaProject javaProject) throws CoreException {
+        IProject project = javaProject.getProject();
+
+        final Updater updater = new Updater(project, javaProject);
+        updater.updateClasspathContainer(true);
 
         WorkspaceJob replaceMarkersJob = new WorkspaceJob("Update bnd classpath markers") {
             @Override
             public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
-                replaceClasspathProblemMarkers(javaProject.getProject(), errors);
+                updater.replaceClasspathProblemMarkers();
                 return Status.OK_STATUS;
             }
         };
-        replaceMarkersJob.setRule(javaProject.getProject());
+
+        replaceMarkersJob.setRule(project);
         replaceMarkersJob.schedule();
     }
 
@@ -91,78 +93,128 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
     }
 
     @Override
-    // The suggested classpath container is ignored here; always recalculated
-    // from the project.
     public void requestClasspathContainerUpdate(IPath containerPath, IJavaProject javaProject, IClasspathContainer containerSuggestion) throws CoreException {
-        BndContainerSourceManager.saveAttachedSources(javaProject.getProject(), (containerSuggestion == null) ? EMPTY_ENTRIES : containerSuggestion.getClasspathEntries());
-
-        ArrayList<String> errors = new ArrayList<String>();
-        calculateAndUpdateClasspathEntries(javaProject, errors);
-        replaceClasspathProblemMarkers(javaProject.getProject(), errors);
-    }
-
-    public static boolean resetClasspaths(Project model, IProject project, Collection<String> errors) throws CoreException {
-        IJavaProject javaProject = JavaCore.create(project);
-        IClasspathContainer container = JavaModelManager.getJavaModelManager().containerGet(javaProject, BndtoolsConstants.BND_CLASSPATH_ID);
-        if (container == null) {
-            return false; // project does not have a BndContainer
-        }
-        container = JavaCore.getClasspathContainer(BndtoolsConstants.BND_CLASSPATH_ID, javaProject);
-        List<IClasspathEntry> currentClasspath = Arrays.asList(container.getClasspathEntries());
-
-        List<IClasspathEntry> newClasspath = calculateProjectClasspath(model, project, errors);
-        newClasspath = BndContainerSourceManager.loadAttachedSources(project, newClasspath);
-
-        replaceClasspathProblemMarkers(project, errors);
-
-        if (!newClasspath.equals(currentClasspath)) {
-            setClasspathEntries(javaProject, newClasspath.toArray(new IClasspathEntry[newClasspath.size()]), model);
-            return true;
-        }
-        return false;
-    }
-
-    private static void calculateAndUpdateClasspathEntries(IJavaProject javaProject, Collection< ? super String> errors) throws CoreException {
-        IClasspathEntry[] entries = EMPTY_ENTRIES;
         IProject project = javaProject.getProject();
-        Project model;
-        try {
-            model = Central.getProject(project.getLocation().toFile());
-        } catch (Exception e) {
-            // Abort quickly if there is no Bnd workspace
-            setClasspathEntries(javaProject, entries, null);
-            return;
+        if (containerSuggestion != null) {
+            BndContainerSourceManager.saveAttachedSources(project, containerSuggestion.getClasspathEntries());
         }
 
-        try {
-            if (model != null) {
-                List<IClasspathEntry> classpath = calculateProjectClasspath(model, project, errors);
-                classpath = BndContainerSourceManager.loadAttachedSources(project, classpath);
-                entries = classpath.toArray(new IClasspathEntry[classpath.size()]);
-            }
-            setClasspathEntries(javaProject, entries, model);
-        } catch (Exception e) {
-            logger.logError("Error requesting bnd classpath update.", e);
-        }
+        Updater updater = new Updater(project, javaProject);
+        updater.updateClasspathContainer(false);
+        updater.replaceClasspathProblemMarkers();
     }
 
+    @Override
+    public String getDescription(IPath containerPath, IJavaProject project) {
+        return "Bnd Bundle Path";
+    }
+
+    /**
+     * ModelListener modelChanged method.
+     */
     @Override
     public void modelChanged(Project model) throws Exception {
         IJavaProject javaProject = Central.getJavaProject(model);
         if (javaProject == null) {
             return; // bnd project is not loaded in the workspace
         }
-        requestClasspathContainerUpdate(BndtoolsConstants.BND_CLASSPATH_ID, javaProject, null);
+        requestClasspathContainerUpdate(javaProject);
     }
 
-    private static void setClasspathEntries(IJavaProject javaProject, IClasspathEntry[] entries, Project model) throws JavaModelException {
-        JavaCore.setClasspathContainer(BndtoolsConstants.BND_CLASSPATH_ID, new IJavaProject[] {
-            javaProject
-        }, new IClasspathContainer[] {
-            new BndContainer(javaProject, entries, null)
-        }, null);
+    /**
+     * Return the BndContainer for the project, if there is one. This will not create one if there is not already one.
+     *
+     * @param javaProject
+     *            The java project of interest. Must not be null.
+     * @return The BndContainer for the java project.
+     */
+    public static IClasspathContainer getClasspathContainer(IJavaProject javaProject) {
+        return JavaModelManager.getJavaModelManager().containerGet(javaProject, BndtoolsConstants.BND_CLASSPATH_ID);
+    }
 
-        if (model != null) {
+    /**
+     * Request the BndContainer for the project, if there is one, be updated. This will not create one if there is not
+     * already one.
+     *
+     * @param javaProject
+     *            The java project of interest. Must not be null.
+     * @throws CoreException
+     */
+    public static void requestClasspathContainerUpdate(IJavaProject javaProject) throws CoreException {
+        if (getClasspathContainer(javaProject) == null) {
+            return; // project does not have a BndContainer
+        }
+        ClasspathContainerInitializer initializer = JavaCore.getClasspathContainerInitializer(BndtoolsConstants.BND_CLASSPATH_ID.segment(0));
+        if (initializer != null) {
+            initializer.requestClasspathContainerUpdate(BndtoolsConstants.BND_CLASSPATH_ID, javaProject, null);
+        }
+    }
+
+    /**
+     * Returns true if the specified project has bnd classpath problem markers.
+     *
+     * @param javaProject
+     *            The java project of interest. Must not be null.
+     * @return true if the specified project has bnd classpath problem markers. false otherwise.
+     * @throws CoreException
+     */
+    public static boolean hasClasspathProblemMarkers(IJavaProject javaProject) throws CoreException {
+        IMarker[] markers = javaProject.getProject().findMarkers(BndtoolsConstants.MARKER_BND_CLASSPATH_PROBLEM, true, IResource.DEPTH_INFINITE);
+        return markers.length > 0; // true if classpath problems
+    }
+
+    private class Updater {
+        private final IProject project;
+        private final IJavaProject javaProject;
+        private final List<String> errors;
+        private final Project model;
+        private boolean updated = false;
+
+        Updater(IProject project, IJavaProject javaProject) {
+            assert project != null;
+            assert javaProject != null;
+            this.project = project;
+            this.javaProject = javaProject;
+            this.errors = new ArrayList<String>();
+            Project p = null;
+            try {
+                p = Central.getProject(project.getLocation().toFile());
+            } catch (Exception e) {
+                logger.logError("Unable to get bnd project for project " + project.getName(), e);
+            }
+            this.model = p;
+        }
+
+        void updateClasspathContainer(boolean init) throws CoreException {
+            if (model == null) {
+                errors.add("Classpath container set to empty. Unable to get bnd project for project " + project.getName());
+                setClasspathEntries(EMPTY_ENTRIES);
+                return;
+            }
+
+            List<IClasspathEntry> newClasspath = calculateProjectClasspath();
+            newClasspath = BndContainerSourceManager.loadAttachedSources(project, newClasspath);
+            if (init) {
+                setClasspathEntries(newClasspath.toArray(new IClasspathEntry[newClasspath.size()]));
+                return;
+            }
+
+            IClasspathContainer container = JavaCore.getClasspathContainer(BndtoolsConstants.BND_CLASSPATH_ID, javaProject);
+            List<IClasspathEntry> currentClasspath = Arrays.asList(container.getClasspathEntries());
+            if (newClasspath.equals(currentClasspath)) {
+                return;
+            }
+            setClasspathEntries(newClasspath.toArray(new IClasspathEntry[newClasspath.size()]));
+        }
+
+        private void setClasspathEntries(IClasspathEntry[] entries) throws JavaModelException {
+            JavaCore.setClasspathContainer(BndtoolsConstants.BND_CLASSPATH_ID, new IJavaProject[] {
+                javaProject
+            }, new IClasspathContainer[] {
+                new BndContainer(entries, getDescription(BndtoolsConstants.BND_CLASSPATH_ID, javaProject))
+            }, null);
+            updated = true;
+
             BndPreferences prefs = new BndPreferences();
             if (prefs.getBuildLogging() == BuildLogger.LOG_FULL) {
                 StringBuilder sb = new StringBuilder();
@@ -173,272 +225,266 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
                 logger.logInfo(sb.append("\n").toString(), null);
             }
         }
-    }
 
-    private static List<IClasspathEntry> calculateProjectClasspath(Project model, IProject project, Collection< ? super String> errors) {
-        final IWorkspaceRoot root = project.getWorkspace().getRoot();
-        if (!project.exists() || !project.isOpen())
-            return Collections.emptyList();
+        private List<IClasspathEntry> calculateProjectClasspath() {
+            final IWorkspaceRoot root = project.getWorkspace().getRoot();
+            if (!project.exists() || !project.isOpen())
+                return Collections.emptyList();
 
-        if (model == null) {
-            errors.add("bnd workspace is not configured.");
-            return Collections.emptyList();
-        }
+            List<Container> containers;
+            try {
+                Collection<Container> buildPath = model.getBuildpath();
+                Collection<Container> testPath = model.getTestpath();
+                Collection<Container> bootClasspath = model.getBootclasspath();
 
-        List<Container> containers;
+                containers = new ArrayList<Container>(buildPath.size() + testPath.size() + bootClasspath.size());
+                containers.addAll(buildPath);
 
-        try {
-            Collection<Container> buildPath = model.getBuildpath();
-            Collection<Container> testPath = model.getTestpath();
-            Collection<Container> bootClasspath = model.getBootclasspath();
-
-            containers = new ArrayList<Container>(buildPath.size() + testPath.size() + bootClasspath.size());
-            containers.addAll(buildPath);
-
-            // The first file is always the project directory,
-            // Eclipse already includes that for us.
-            if (containers.size() > 0) {
-                containers.remove(0);
-            }
-            containers.addAll(testPath);
-            containers.addAll(bootClasspath);
-        } catch (CircularDependencyException e) {
-            errors.add("Circular dependency: " + e.getMessage());
-            containers = Collections.emptyList();
-        } catch (Exception e) {
-            errors.add("Unexpected error during classpath calculation: " + e);
-            containers = Collections.emptyList();
-        }
-
-        List<IClasspathEntry> result = new ArrayList<IClasspathEntry>(containers.size());
-        List<File> filesToRefresh = new ArrayList<File>(containers.size());
-        for (Container c : containers) {
-            if (c.getError() != null) {
-                SetLocation location = model.error("%s-%s: %s", c.getBundleSymbolicName(), c.getVersion(), c.getError());
-                location.context(c.getBundleSymbolicName());
-                location.header(Constants.BUILDPATH);
-                location.file(model.getPropertiesFile().getAbsolutePath());
-                errors.add(c.getError());
-                continue;
+                // The first file is always the project directory,
+                // Eclipse already includes that for us.
+                if (containers.size() > 0) {
+                    containers.remove(0);
+                }
+                containers.addAll(testPath);
+                containers.addAll(bootClasspath);
+            } catch (CircularDependencyException e) {
+                errors.add("Circular dependency: " + e.getMessage());
+                containers = Collections.emptyList();
+            } catch (Exception e) {
+                errors.add("Unexpected error during classpath calculation: " + e);
+                containers = Collections.emptyList();
             }
 
-            File file = c.getFile();
-            assert file.isAbsolute();
+            List<IClasspathEntry> result = new ArrayList<IClasspathEntry>(containers.size());
+            List<File> filesToRefresh = new ArrayList<File>(containers.size());
+            for (Container c : containers) {
+                if (c.getError() != null) {
+                    SetLocation location = model.error("%s-%s: %s", c.getBundleSymbolicName(), c.getVersion(), c.getError());
+                    location.context(c.getBundleSymbolicName());
+                    location.header(Constants.BUILDPATH);
+                    location.file(model.getPropertiesFile().getAbsolutePath());
+                    errors.add(c.getError());
+                    continue;
+                }
 
-            if (!file.exists()) {
+                File file = c.getFile();
+                assert file.isAbsolute();
+
+                if (!file.exists()) {
+                    switch (c.getType()) {
+                    case REPO :
+                        errors.add("Repository file " + file + " does not exist");
+                        break;
+                    case LIBRARY :
+                        errors.add("Library file " + file + " does not exist");
+                        break;
+                    case PROJECT :
+                        errors.add("Project bundle " + file + " does not exist");
+                        break;
+                    case EXTERNAL :
+                        errors.add("External file " + file + " does not exist");
+                        break;
+                    default :
+                        break;
+                    }
+                }
+
+                IPath path = null;
+                try {
+                    path = fileToPath(file);
+                    filesToRefresh.add(file);
+                } catch (Exception e) {
+                    errors.add(String.format("Failed to convert file %s to Eclipse path: %s: %s", file, e.getClass().getName(), e.getMessage()));
+                }
+                if (path == null) {
+                    continue;
+                }
+
+                IClasspathAttribute[] extraAttrs = calculateContainerAttributes(c);
+                IAccessRule[] accessRules = toAccessRulesArray(calculateContainerAccessRules(c));
                 switch (c.getType()) {
-                case REPO :
-                    errors.add("Repository file " + file + " does not exist");
-                    break;
-                case LIBRARY :
-                    errors.add("Library file " + file + " does not exist");
-                    break;
                 case PROJECT :
-                    errors.add("Project bundle " + file + " does not exist");
-                    break;
-                case EXTERNAL :
-                    errors.add("External file " + file + " does not exist");
+                    IPath projectPath = root.getFile(path).getProject().getFullPath();
+                    result.add(JavaCore.newProjectEntry(projectPath, accessRules, false, extraAttrs, false));
+                    if (!isVersionProject(c)) { // if not version=project, add entry for generated jar
+                        result.add(JavaCore.newLibraryEntry(path, path, null, accessRules, extraAttrs, false));
+                    }
                     break;
                 default :
+                    result.add(JavaCore.newLibraryEntry(path, path, null, accessRules, extraAttrs, false));
                     break;
                 }
             }
 
-            IPath path = null;
-            try {
-                path = fileToPath(file);
-                filesToRefresh.add(file);
-            } catch (Exception e) {
-                errors.add(String.format("Failed to convert file %s to Eclipse path: %s: %s", file, e.getClass().getName(), e.getMessage()));
-            }
-            if (path == null) {
-                continue;
+            // Refresh once, instead of for each dependent project.
+            RefreshFileJob refreshJob = new RefreshFileJob(filesToRefresh, false, project);
+            if (refreshJob.needsToSchedule())
+                refreshJob.schedule(100);
+
+            errors.addAll(model.getErrors());
+
+            return result;
+        }
+
+        private IClasspathAttribute[] calculateContainerAttributes(Container c) {
+            List<IClasspathAttribute> attrs = new ArrayList<IClasspathAttribute>();
+            attrs.add(JavaCore.newClasspathAttribute("bsn", c.getBundleSymbolicName()));
+            attrs.add(JavaCore.newClasspathAttribute("type", c.getType().name()));
+            attrs.add(JavaCore.newClasspathAttribute("project", c.getProject().getName()));
+
+            String version = c.getAttributes().get(Constants.VERSION_ATTRIBUTE);
+            if (version != null) {
+                attrs.add(JavaCore.newClasspathAttribute(Constants.VERSION_ATTRIBUTE, version));
             }
 
-            IClasspathAttribute[] extraAttrs = calculateContainerAttributes(c);
-            IAccessRule[] accessRules = toAccessRulesArray(calculateContainerAccessRules(c));
+            String packages = c.getAttributes().get("packages");
+            if (packages != null) {
+                attrs.add(JavaCore.newClasspathAttribute("packages", packages));
+            }
+
+            return attrs.toArray(new IClasspathAttribute[attrs.size()]);
+        }
+
+        private List<IAccessRule> calculateContainerAccessRules(Container c) {
+            String packageList = c.getAttributes().get("packages");
+            if (packageList != null) {
+                // Use packages=* for full access
+                List<IAccessRule> accessRules = new ArrayList<IAccessRule>();
+                for (String exportPkg : packageList.trim().split("\\s*,\\s*")) {
+                    Matcher m = packagePattern.matcher(exportPkg);
+                    StringBuffer pathStr = new StringBuffer(exportPkg.length() + 1);
+                    while (m.find()) {
+                        m.appendReplacement(pathStr, m.group().equals("*") ? "**" : "/");
+                    }
+                    m.appendTail(pathStr).append("/*");
+                    accessRules.add(JavaCore.newAccessRule(new Path(pathStr.toString()), IAccessRule.K_ACCESSIBLE));
+                }
+                return accessRules;
+            }
+
             switch (c.getType()) {
             case PROJECT :
-                IPath projectPath = root.getFile(path).getProject().getFullPath();
-                result.add(JavaCore.newProjectEntry(projectPath, accessRules, false, extraAttrs, false));
-                if (!isVersionProject(c)) { // if not version=project, add entry for generated jar
-                    result.add(JavaCore.newLibraryEntry(path, path, null, accessRules, extraAttrs, false));
+                if (isVersionProject(c)) { // if version=project, try Project for exports
+                    return calculateProjectAccessRules(c.getProject());
                 }
-                break;
+                //$FALL-THROUGH$
+            case REPO :
+            case EXTERNAL :
+                Manifest mf = null;
+                try {
+                    mf = JarUtils.loadJarManifest(c.getFile());
+                } catch (IOException e) {
+                    break; // unable to open manifest; so full access
+                }
+                if (mf == null) {
+                    break; // no manifest; so full access
+                }
+                if (mf.getMainAttributes().getValue(Constants.BUNDLE_MANIFESTVERSION) == null) {
+                    break; // not a bundle; so full access
+                }
+                List<IAccessRule> accessRules = new ArrayList<IAccessRule>();
+                Parameters exportPkgs = new Parameters(mf.getMainAttributes().getValue(Constants.EXPORT_PACKAGE));
+                for (String exportPkg : exportPkgs.keySet()) {
+                    String pathStr = exportPkg.replace('.', '/') + "/*";
+                    accessRules.add(JavaCore.newAccessRule(new Path(pathStr), IAccessRule.K_ACCESSIBLE));
+                }
+                return accessRules;
             default :
-                result.add(JavaCore.newLibraryEntry(path, path, null, accessRules, extraAttrs, false));
                 break;
             }
+
+            return null; // full access
         }
 
-        // Refresh once, instead of for each dependent project.
-        RefreshFileJob refreshJob = new RefreshFileJob(filesToRefresh, false, project);
-        if (refreshJob.needsToSchedule())
-            refreshJob.schedule(100);
-
-        errors.addAll(model.getErrors());
-
-        return result;
-    }
-
-    private static IClasspathAttribute[] calculateContainerAttributes(Container c) {
-        List<IClasspathAttribute> attrs = new ArrayList<IClasspathAttribute>();
-        attrs.add(JavaCore.newClasspathAttribute("bsn", c.getBundleSymbolicName()));
-        attrs.add(JavaCore.newClasspathAttribute("type", c.getType().name()));
-        attrs.add(JavaCore.newClasspathAttribute("project", c.getProject().getName()));
-
-        String version = c.getAttributes().get(Constants.VERSION_ATTRIBUTE);
-        if (version != null) {
-            attrs.add(JavaCore.newClasspathAttribute(Constants.VERSION_ATTRIBUTE, version));
-        }
-
-        String packages = c.getAttributes().get("packages");
-        if (packages != null) {
-            attrs.add(JavaCore.newClasspathAttribute("packages", packages));
-        }
-
-        return attrs.toArray(new IClasspathAttribute[attrs.size()]);
-    }
-
-    private static final Pattern packagePattern = Pattern.compile("(?<=^|\\.)\\*(?=\\.|$)|\\.");
-
-    private static List<IAccessRule> calculateContainerAccessRules(Container c) {
-        String packageList = c.getAttributes().get("packages");
-        if (packageList != null) {
-            // Use packages=* for full access
-            List<IAccessRule> accessRules = new ArrayList<IAccessRule>();
-            for (String exportPkg : packageList.trim().split("\\s*,\\s*")) {
-                Matcher m = packagePattern.matcher(exportPkg);
-                StringBuffer pathStr = new StringBuffer(exportPkg.length() + 1);
-                while (m.find()) {
-                    m.appendReplacement(pathStr, m.group().equals("*") ? "**" : "/");
+        private List<IAccessRule> calculateProjectAccessRules(Project p) {
+            File accessPatternsFile = new File(BuilderPlugin.getInstance().getStateLocation().toFile(), p.getName() + ".accesspatterns");
+            String oldAccessPatterns = "";
+            boolean exists = accessPatternsFile.exists();
+            if (exists) { // read persisted access patterns
+                try {
+                    oldAccessPatterns = IO.collect(accessPatternsFile);
+                } catch (final IOException e) {
+                    logger.logError("Failed to read access patterns file for project " + p.getName(), e);
                 }
-                m.appendTail(pathStr).append("/*");
-                accessRules.add(JavaCore.newAccessRule(new Path(pathStr.toString()), IAccessRule.K_ACCESSIBLE));
             }
-            return accessRules;
-        }
 
-        switch (c.getType()) {
-        case PROJECT :
-            if (isVersionProject(c)) { // if version=project, try Project for exports
-                return calculateProjectAccessRules(c.getProject());
+            if (p.getContained().isEmpty()) { // project not recently built; use persisted access patterns
+                if (!exists) {
+                    return null; // no persisted access patterns; full access
+                }
+                String[] patterns = oldAccessPatterns.split(",");
+                List<IAccessRule> accessRules = new ArrayList<IAccessRule>(patterns.length);
+                for (String pathStr : patterns) {
+                    accessRules.add(JavaCore.newAccessRule(new Path(pathStr), IAccessRule.K_ACCESSIBLE));
+                }
+                return accessRules;
             }
-            //$FALL-THROUGH$
-        case REPO :
-        case EXTERNAL :
-            Manifest mf = null;
-            try {
-                mf = JarUtils.loadJarManifest(c.getFile());
-            } catch (IOException e) {
-                break; // unable to open manifest; so full access
-            }
-            if (mf == null) {
-                break; // no manifest; so full access
-            }
-            if (mf.getMainAttributes().getValue(Constants.BUNDLE_MANIFESTVERSION) == null) {
-                break; // not a bundle; so full access
-            }
-            List<IAccessRule> accessRules = new ArrayList<IAccessRule>();
-            Parameters exportPkgs = new Parameters(mf.getMainAttributes().getValue(Constants.EXPORT_PACKAGE));
-            for (String exportPkg : exportPkgs.keySet()) {
-                String pathStr = exportPkg.replace('.', '/') + "/*";
+
+            Set<PackageRef> exportPkgs = p.getExports().keySet();
+            List<IAccessRule> accessRules = new ArrayList<IAccessRule>(exportPkgs.size());
+            StringBuilder sb = new StringBuilder(oldAccessPatterns.length());
+            for (PackageRef exportPkg : exportPkgs) {
+                String pathStr = exportPkg.getBinary() + "/*";
+                if (sb.length() > 0) {
+                    sb.append(',');
+                }
+                sb.append(pathStr);
                 accessRules.add(JavaCore.newAccessRule(new Path(pathStr), IAccessRule.K_ACCESSIBLE));
             }
-            return accessRules;
-        default :
-            break;
-        }
 
-        return null; // full access
-    }
+            String newAccessPatterns = sb.toString();
+            if (!exists || !newAccessPatterns.equals(oldAccessPatterns)) { // if state changed; persist updated access patterns
+                try {
+                    IO.store(newAccessPatterns, accessPatternsFile);
+                } catch (final IOException e) {
+                    logger.logError("Failed to write access patterns file for project " + p.getName(), e);
+                }
+            }
 
-    private static List<IAccessRule> calculateProjectAccessRules(Project p) {
-        File accessPatternsFile = new File(BuilderPlugin.getInstance().getStateLocation().toFile(), p.getName() + ".accesspatterns");
-        String oldAccessPatterns = "";
-        boolean exists = accessPatternsFile.exists();
-        if (exists) { // read persisted access patterns
-            try {
-                oldAccessPatterns = IO.collect(accessPatternsFile);
-            } catch (final IOException e) {
-                logger.logError("Failed to read access patterns file for project " + p.getName(), e);
-            }
-        }
-
-        if (p.getContained().isEmpty()) { // project not recently built; use persisted access patterns
-            if (!exists) {
-                return null; // no persisted access patterns; full access
-            }
-            String[] patterns = oldAccessPatterns.split(",");
-            List<IAccessRule> accessRules = new ArrayList<IAccessRule>(patterns.length);
-            for (String pathStr : patterns) {
-                accessRules.add(JavaCore.newAccessRule(new Path(pathStr), IAccessRule.K_ACCESSIBLE));
-            }
             return accessRules;
         }
 
-        Set<PackageRef> exportPkgs = p.getExports().keySet();
-        List<IAccessRule> accessRules = new ArrayList<IAccessRule>(exportPkgs.size());
-        StringBuilder sb = new StringBuilder(oldAccessPatterns.length());
-        for (PackageRef exportPkg : exportPkgs) {
-            String pathStr = exportPkg.getBinary() + "/*";
-            if (sb.length() > 0) {
-                sb.append(',');
+        private IAccessRule[] toAccessRulesArray(List<IAccessRule> rules) {
+            if (rules == null) {
+                return null;
             }
-            sb.append(pathStr);
-            accessRules.add(JavaCore.newAccessRule(new Path(pathStr), IAccessRule.K_ACCESSIBLE));
+            final int size = rules.size();
+            IAccessRule[] accessRules = rules.toArray(new IAccessRule[size + 1]);
+            accessRules[size] = DISCOURAGED;
+            return accessRules;
         }
 
-        String newAccessPatterns = sb.toString();
-        if (!exists || !newAccessPatterns.equals(oldAccessPatterns)) { // if state changed; persist updated access patterns
-            try {
-                IO.store(newAccessPatterns, accessPatternsFile);
-            } catch (final IOException e) {
-                logger.logError("Failed to write access patterns file for project " + p.getName(), e);
+        void replaceClasspathProblemMarkers() throws CoreException {
+            if (!project.exists() || !project.isOpen()) {
+                logger.logError(String.format("Cannot replace bnd classpath problem markers: project %s is not in the Eclipse workspace or is not open.", project.getName()), null);
+                return;
+            }
+
+            if (!updated && errors.isEmpty()) {
+                return;
+            }
+
+            IResource resource = project.getFile(Project.BNDFILE);
+            if (resource == null || !resource.exists())
+                resource = project;
+
+            project.deleteMarkers(BndtoolsConstants.MARKER_BND_CLASSPATH_PROBLEM, true, IResource.DEPTH_INFINITE);
+            for (String error : errors) {
+                IMarker marker = resource.createMarker(BndtoolsConstants.MARKER_BND_CLASSPATH_PROBLEM);
+                marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+                marker.setAttribute(IMarker.MESSAGE, error);
             }
         }
 
-        return accessRules;
-    }
-
-    private static IAccessRule[] toAccessRulesArray(List<IAccessRule> rules) {
-        if (rules == null) {
-            return null;
-        }
-        final int size = rules.size();
-        IAccessRule[] accessRules = rules.toArray(new IAccessRule[size + 1]);
-        accessRules[size] = DISCOURAGED;
-        return accessRules;
-    }
-
-    private static void replaceClasspathProblemMarkers(IProject project, Collection<String> errors) throws CoreException {
-        assert project != null;
-
-        if (!project.exists() || !project.isOpen()) {
-            logger.logError(String.format("Cannot replace bnd classpath problem markers: project %s is not in the Eclipse workspace or is not open.", project.getName()), null);
-            return;
+        private IPath fileToPath(File file) throws Exception {
+            IPath path = Central.toPath(file);
+            if (path == null)
+                path = Path.fromOSString(file.getAbsolutePath());
+            return path;
         }
 
-        IResource resource = project.getFile(Project.BNDFILE);
-        if (resource == null || !resource.exists())
-            resource = project;
-
-        project.deleteMarkers(BndtoolsConstants.MARKER_BND_CLASSPATH_PROBLEM, true, IResource.DEPTH_INFINITE);
-        for (String error : errors) {
-            IMarker marker = resource.createMarker(BndtoolsConstants.MARKER_BND_CLASSPATH_PROBLEM);
-            marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
-            marker.setAttribute(IMarker.MESSAGE, error);
+        private boolean isVersionProject(Container c) {
+            return Constants.VERSION_ATTR_PROJECT.equals(c.getAttributes().get(Constants.VERSION_ATTRIBUTE));
         }
-    }
-
-    private static IPath fileToPath(File file) throws Exception {
-        IPath path = Central.toPath(file);
-        if (path == null)
-            path = Path.fromOSString(file.getAbsolutePath());
-        return path;
-    }
-
-    private static boolean isVersionProject(Container c) {
-        return Constants.VERSION_ATTR_PROJECT.equals(c.getAttributes().get(Constants.VERSION_ATTRIBUTE));
     }
 }

--- a/bndtools.builder/src/org/bndtools/builder/jobs/newproject/AdjustClasspathsForNewProjectJob.java
+++ b/bndtools.builder/src/org/bndtools/builder/jobs/newproject/AdjustClasspathsForNewProjectJob.java
@@ -1,7 +1,6 @@
 package org.bndtools.builder.jobs.newproject;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.bndtools.api.ILogger;
@@ -17,6 +16,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 
 import aQute.bnd.build.Project;
 import bndtools.central.Central;
@@ -47,10 +48,12 @@ class AdjustClasspathsForNewProjectJob extends WorkspaceJob {
             Project project = projects.remove(0);
             IProject eclipseProject = WorkspaceUtils.findOpenProject(wsroot, project);
             if (eclipseProject != null && !eclipseProject.equals(addedProject)) {
-                List<String> errors = new LinkedList<String>();
                 try {
                     project.propertiesChanged();
-                    BndContainerInitializer.resetClasspaths(project, eclipseProject, errors);
+                    IJavaProject javaProject = JavaCore.create(eclipseProject);
+                    if (javaProject != null) {
+                        BndContainerInitializer.requestClasspathContainerUpdate(javaProject);
+                    }
                 } catch (CoreException e) {
                     logger.logStatus(e.getStatus());
                     return Status.CANCEL_STATUS;


### PR DESCRIPTION
#944 shows a deadlock where two threads (incremental builder and AdjustClasspathsForNewProjectJob) call the classpath container to update classpaths for projects. We need to protect against multiple threads from calling into the non-thread-safe bnd code.