### PR TITLE
classpath: Remove setting of classpath error markers

### DIFF
--- a/bndtools.api/src/org/bndtools/api/BndtoolsConstants.java
+++ b/bndtools.api/src/org/bndtools/api/BndtoolsConstants.java
@@ -5,13 +5,11 @@ import org.eclipse.core.runtime.Path;
 
 public final class BndtoolsConstants {
 
-	public static final String CORE_PLUGIN_ID = "bndtools.core";
+    public static final String CORE_PLUGIN_ID = "bndtools.core";
     public static final String NATURE_ID = CORE_PLUGIN_ID + ".bndnature";
     public static final String BUILDER_ID = CORE_PLUGIN_ID + ".bndbuilder";
 
     public static final IPath BND_CLASSPATH_ID = new Path("aQute.bnd.classpath.container");
 
     public static final String MARKER_BND_PROBLEM = "bndtools.builder.bndproblem";
-    public static final String MARKER_BND_CLASSPATH_PROBLEM = "bndtools.builder.bnd_classpath_problem";
-
 }

--- a/bndtools.core/src/bndtools/editor/pages/ProjectBuildPage.java
+++ b/bndtools.core/src/bndtools/editor/pages/ProjectBuildPage.java
@@ -72,10 +72,12 @@ public class ProjectBuildPage extends FormPage implements IPriority, IResourceCh
     private final ExtendedFormEditor editor;
 
     public static final IFormPageFactory FACTORY = new IFormPageFactory() {
+        @Override
         public IFormPage createPage(ExtendedFormEditor editor, BndEditModel model, String id) throws IllegalArgumentException {
             return new ProjectBuildPage(editor, model, id, "Build");
         }
 
+        @Override
         public boolean supportsMode(Mode mode) {
             return mode == Mode.project;
         }
@@ -160,8 +162,6 @@ public class ProjectBuildPage extends FormPage implements IPriority, IResourceCh
             try {
                 IMarker[] markers;
 
-                markers = resource.findMarkers(BndtoolsConstants.MARKER_BND_CLASSPATH_PROBLEM, true, 0);
-                loadMarkers(markers);
                 markers = resource.findMarkers(BndtoolsConstants.MARKER_BND_PROBLEM, true, 0);
                 loadMarkers(markers);
             } catch (CoreException e) {
@@ -246,6 +246,7 @@ public class ProjectBuildPage extends FormPage implements IPriority, IResourceCh
         }
     }
 
+    @Override
     public int getPriority() {
         if (problemSeverity >= IMarker.SEVERITY_ERROR)
             return 10;
@@ -259,6 +260,7 @@ public class ProjectBuildPage extends FormPage implements IPriority, IResourceCh
         return pageImage;
     }
 
+    @Override
     public void resourceChanged(IResourceChangeEvent event) {
         IResource myResource = ResourceUtil.getResource(getEditorInput());
 
@@ -272,6 +274,7 @@ public class ProjectBuildPage extends FormPage implements IPriority, IResourceCh
 
         if ((delta.getKind() & IResourceDelta.CHANGED) != 0 && (delta.getFlags() & IResourceDelta.MARKERS) != 0) {
             getEditorSite().getShell().getDisplay().asyncExec(new Runnable() {
+                @Override
                 public void run() {
                     loadProblems();
                     reportProblemsInHeader();


### PR DESCRIPTION
The container initializer will now put all errors in the model and the
incremental builder will be responsible for setting the error markers.

Currently the incremental builder loses the errors, so it needs to be
changed. @pkriens is working on this change. The incremental builder
also needs to make sure Project.prepare() is run each incremental build
to generate any classpath errors that exist into the model. Otherwise
the classpath errors will be lost if the model is cleared each build.

Since the incremental builder is now responsible for all error markers,
the bnd classpath problem marker type is also deleted.

Fixes https://github.com/bndtools/bndtools/issues/1037

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>