### PR TITLE
Fix NPE: Return an empty map instead of null

### DIFF
--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
@@ -76,36 +76,34 @@ class NewBndProjectWizard extends AbstractNewBndProjectWizard {
         }
         try {
             Map<String,String> sourceOutputLocations = JavaProjectUtils.getSourceOutputLocations(pageTwo.getJavaProject());
-            if (sourceOutputLocations != null) {
-                int nr = 1;
-                for (Map.Entry<String,String> entry : sourceOutputLocations.entrySet()) {
-                    String src = entry.getKey();
-                    String bin = entry.getValue();
+            int nr = 1;
+            for (Map.Entry<String,String> entry : sourceOutputLocations.entrySet()) {
+                String src = entry.getKey();
+                String bin = entry.getValue();
 
-                    if (nr == 1) {
-                        if (!bndPaths.getSrc().equals(src)) {
-                            model.genericSet(Constants.DEFAULT_PROP_SRC_DIR, src);
-                        }
-                        if (!bndPaths.getBin().equals(bin)) {
-                            model.genericSet(Constants.DEFAULT_PROP_BIN_DIR, bin);
-                        }
-                        nr = 2;
-                    } else if (nr == 2) {
-                        if (!bndPaths.getTestSrc().equals(src)) {
-                            model.genericSet(Constants.DEFAULT_PROP_TESTSRC_DIR, src);
-                        }
-                        if (!bndPaths.getTestBin().equals(bin)) {
-                            model.genericSet(Constants.DEFAULT_PROP_TESTBIN_DIR, bin);
-                        }
-                        nr = 2;
-                    } else {
-                        // if for some crazy reason we end up with more than 2 paths, we log them in
-                        // extension properties (we cannot write comments) but this should never happen
-                        // anyway since the second page will not complete if there are not exactly 2 paths
-                        // so this could only happen if someone adds another page (that changes them again)
-                        model.genericSet("X-WARN-" + nr, "Ignoring source path " + src + " -> " + bin);
-                        nr++;
+                if (nr == 1) {
+                    if (!bndPaths.getSrc().equals(src)) {
+                        model.genericSet(Constants.DEFAULT_PROP_SRC_DIR, src);
                     }
+                    if (!bndPaths.getBin().equals(bin)) {
+                        model.genericSet(Constants.DEFAULT_PROP_BIN_DIR, bin);
+                    }
+                    nr = 2;
+                } else if (nr == 2) {
+                    if (!bndPaths.getTestSrc().equals(src)) {
+                        model.genericSet(Constants.DEFAULT_PROP_TESTSRC_DIR, src);
+                    }
+                    if (!bndPaths.getTestBin().equals(bin)) {
+                        model.genericSet(Constants.DEFAULT_PROP_TESTBIN_DIR, bin);
+                    }
+                    nr = 2;
+                } else {
+                    // if for some crazy reason we end up with more than 2 paths, we log them in
+                    // extension properties (we cannot write comments) but this should never happen
+                    // anyway since the second page will not complete if there are not exactly 2 paths
+                    // so this could only happen if someone adds another page (that changes them again)
+                    model.genericSet("X-WARN-" + nr, "Ignoring source path " + src + " -> " + bin);
+                    nr++;
                 }
             }
 

--- a/bndtools.utils/src/org/bndtools/utils/javaproject/JavaProjectUtils.java
+++ b/bndtools.utils/src/org/bndtools/utils/javaproject/JavaProjectUtils.java
@@ -1,5 +1,6 @@
 package org.bndtools.utils.javaproject;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -8,53 +9,51 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 
 public class JavaProjectUtils {
-	/**
-	 * Access the project's (Eclipse) classpath to determine the source
-	 * directories and their output directories
-	 * 
-	 * @param project
-	 *            the project
-	 * @return a map of source directories and their output directories, all
-	 *         relative to the project directory. null when project is null or
-	 *         when an error occurred.
-	 */
-	static public Map<String, String> getSourceOutputLocations(IJavaProject project) {
-		if (project == null) {
-			return null;
-		}
+    /**
+     * Access the project's (Eclipse) classpath to determine the source directories and their output directories
+     *
+     * @param project
+     *            the project
+     * @return a map of source directories and their output directories, all relative to the project directory. empty
+     *         map when project is null or when an error occurred.
+     */
+    static public Map<String,String> getSourceOutputLocations(IJavaProject project) {
+        if (project == null) {
+            return Collections.emptyMap();
+        }
 
-		IClasspathEntry[] classPathEntries = null;
-		IPath defaultOutputLocation = null;
-		try {
-			classPathEntries = project.getRawClasspath();
-			defaultOutputLocation = project.getOutputLocation();
-		} catch (Throwable e) {
-			return null;
-		}
+        IClasspathEntry[] classPathEntries = null;
+        IPath defaultOutputLocation = null;
+        try {
+            classPathEntries = project.getRawClasspath();
+            defaultOutputLocation = project.getOutputLocation();
+        } catch (Throwable e) {
+            return Collections.emptyMap();
+        }
 
-		if (classPathEntries == null || defaultOutputLocation == null) {
-			return null;
-		}
+        if (classPathEntries == null || defaultOutputLocation == null) {
+            return Collections.emptyMap();
+        }
 
-		IPath projectPath = project.getPath();
+        IPath projectPath = project.getPath();
 
-		Map<String, String> sourceOutputLocations = new LinkedHashMap<String, String>();
-		for (IClasspathEntry classPathEntry : classPathEntries) {
-			if (classPathEntry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
-				IPath src = classPathEntry.getPath();
-				IPath bin = classPathEntry.getOutputLocation();
+        Map<String,String> sourceOutputLocations = new LinkedHashMap<String,String>();
+        for (IClasspathEntry classPathEntry : classPathEntries) {
+            if (classPathEntry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+                IPath src = classPathEntry.getPath();
+                IPath bin = classPathEntry.getOutputLocation();
 
-				if (bin == null) {
-					bin = defaultOutputLocation;
-				}
+                if (bin == null) {
+                    bin = defaultOutputLocation;
+                }
 
-				assert (src != null);
-				assert (bin != null);
+                assert (src != null);
+                assert (bin != null);
 
-				sourceOutputLocations.put(src.makeRelativeTo(projectPath).toString(), bin.makeRelativeTo(projectPath).toString());
-			}
-		}
+                sourceOutputLocations.put(src.makeRelativeTo(projectPath).toString(), bin.makeRelativeTo(projectPath).toString());
+            }
+        }
 
-		return sourceOutputLocations;
-	}
+        return sourceOutputLocations;
+    }
 }

--- a/org.bndtools.versioncontrol.ignores.manager/src/org/bndtools/versioncontrol/ignores/manager/VersionControlIgnoresManagerImpl.java
+++ b/org.bndtools.versioncontrol.ignores.manager/src/org/bndtools/versioncontrol/ignores/manager/VersionControlIgnoresManagerImpl.java
@@ -56,6 +56,7 @@ public class VersionControlIgnoresManagerImpl implements VersionControlIgnoresMa
      * VersionControlIgnoresManager
      */
 
+    @Override
     public String sanitiseGitIgnoreGlob(boolean rooted, String ignoreGlob, boolean directory) {
         /* trim */
         String newPath = ignoreGlob.trim();
@@ -72,6 +73,7 @@ public class VersionControlIgnoresManagerImpl implements VersionControlIgnoresMa
         return String.format("%s%s%s", rooted ? "/" : "", newPath, directory ? "/" : "");
     }
 
+    @Override
     public void addIgnores(Set<String> plugins, File dstDir, String ignores) {
         List<String> ignoredEntries = null;
         if (ignores != null && ignores.trim() != null) {
@@ -88,6 +90,7 @@ public class VersionControlIgnoresManagerImpl implements VersionControlIgnoresMa
         addIgnores(plugins, dstDir, ignoredEntries);
     }
 
+    @Override
     public void addIgnores(Set<String> plugins, File dstDir, List<String> ignores) {
         if (plugins == null || plugins.isEmpty()) {
             return;
@@ -110,6 +113,7 @@ public class VersionControlIgnoresManagerImpl implements VersionControlIgnoresMa
         }
     }
 
+    @Override
     public Set<String> getPluginsForProjectRepositoryProviderId(String repositoryProviderId) {
         if (repositoryProviderId == null || repositoryProviderId.length() == 0) {
             return null;
@@ -136,12 +140,14 @@ public class VersionControlIgnoresManagerImpl implements VersionControlIgnoresMa
         return null;
     }
 
+    @Override
     public Collection<NamedPlugin> getAllPluginsInformation() {
         synchronized (plugins) {
             return Collections.unmodifiableCollection(pluginsInformation.values());
         }
     }
 
+    @Override
     public void createProjectIgnores(Set<String> plugins, File projectDir, Map<String,String> sourceOutputLocations, String targetDir) {
         if (projectDir == null || plugins == null || plugins.isEmpty()) {
             return;
@@ -158,31 +164,29 @@ public class VersionControlIgnoresManagerImpl implements VersionControlIgnoresMa
 
             List<String> projectIgnores = new LinkedList<String>();
 
-            if (sourceOutputLocations != null) {
-                List<String> emptyIgnores = new LinkedList<String>();
-                for (Map.Entry<String,String> sourceOutputLocation : sourceOutputLocations.entrySet()) {
-                    String srcDir = sourceOutputLocation.getKey();
-                    String binDir = sourceOutputLocation.getValue();
-                    assert (srcDir != null);
-                    assert (binDir != null);
+            List<String> emptyIgnores = new LinkedList<String>();
+            for (Map.Entry<String,String> sourceOutputLocation : sourceOutputLocations.entrySet()) {
+                String srcDir = sourceOutputLocation.getKey();
+                String binDir = sourceOutputLocation.getValue();
+                assert (srcDir != null);
+                assert (binDir != null);
 
-                    File srcDirFile = new File(projectDir, srcDir);
+                File srcDirFile = new File(projectDir, srcDir);
 
-                    /*
-                     * when the version control system can't store empty directories and
-                     * the source directory doesn't exist or is empty, then add empty ignores
-                     */
-                    if (!plugin.canStoreEmptyDirectories() && (!srcDirFile.exists() || (srcDirFile.list().length == 0))) {
-                        try {
-                            plugin.addIgnores(srcDirFile, emptyIgnores);
-                        } catch (Throwable e) {
-                            logger.logError(String.format("Unable to add empty %s ignores to the project in %s", plugin.getInformation().getName(), projectDir), e);
-                        }
+                /*
+                 * when the version control system can't store empty directories and
+                 * the source directory doesn't exist or is empty, then add empty ignores
+                 */
+                if (!plugin.canStoreEmptyDirectories() && (!srcDirFile.exists() || (srcDirFile.list().length == 0))) {
+                    try {
+                        plugin.addIgnores(srcDirFile, emptyIgnores);
+                    } catch (Throwable e) {
+                        logger.logError(String.format("Unable to add empty %s ignores to the project in %s", plugin.getInformation().getName(), projectDir), e);
                     }
-
-                    /* add the corresponding output location to the project ignores */
-                    projectIgnores.add(sanitiseGitIgnoreGlob(true, binDir, true));
                 }
+
+                /* add the corresponding output location to the project ignores */
+                projectIgnores.add(sanitiseGitIgnoreGlob(true, binDir, true));
             }
 
             if (targetDir != null && !targetDir.isEmpty()) {


### PR DESCRIPTION
JavaProjectUtils.getSourceOutputLocations returned null in certain
circumstances. It now returns an empty map.

Fixes https://github.com/bndtools/bndtools/issues/455

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>