### PR TITLE
Fixed logging when postponed returned & markers

### DIFF
--- a/bndtools.api/src/org/bndtools/api/BndtoolsConstants.java
+++ b/bndtools.api/src/org/bndtools/api/BndtoolsConstants.java
@@ -3,6 +3,8 @@ package org.bndtools.api;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 
+import aQute.service.reporter.Report.Location;
+
 public final class BndtoolsConstants {
 
     public static final String CORE_PLUGIN_ID = "bndtools.core";
@@ -14,4 +16,24 @@ public final class BndtoolsConstants {
     public static final String MARKER_BND_PROBLEM = "bndtools.builder.bndproblem";
     public static final String MARKER_BND_PATH_PROBLEM = "bndtools.builder.bndpathproblem";
     public static final String MARKER_BND_WORKSPACE_PROBLEM = "bndtools.builder.bndworkspaceproblem";
+
+    /**
+     * Marker attribute name for the bnd {@link Location#context}
+     */
+    public static final String BNDTOOLS_MARKER_CONTEXT_ATTR = "bndtools.marker.context";
+    /**
+     * Marker attribute name for the bnd {@link Location#header}
+     */
+    public static final String BNDTOOLS_MARKER_HEADER_ATTR = "bndtools.marker.header";
+
+    /**
+     * Marker attribute name for the bnd {@link Location#reference}
+     */
+    public static final String BNDTOOLS_MARKER_REFERENCE_ATTR = "bndtools.marker.reference";
+
+    /**
+     * Marker attribute name for the bnd {@link Location#file}
+     */
+    public static final String BNDTOOLS_MARKER_FILE_ATTR = "bndtools.marker.file";
+
 }

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -200,6 +200,9 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
             //
             // We did not postpone, so reset the flag
             //
+            if (postponed)
+                buildLog.full("Was postponed");
+
             force |= postponed;
             postponed = false;
 
@@ -226,8 +229,10 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
             // no reason to rebuild.
             //
 
-            if (!force)
+            if (!force) {
+                buildLog.full("Auto/Incr. build, no changes detected");
                 return noreport();
+            }
 
             if (model.isNoBundles()) {
                 buildLog.basic("-nobundles was set, so no build");
@@ -272,7 +277,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
         } catch (Exception e) {
             throw new CoreException(new Status(IStatus.ERROR, PLUGIN_ID, 0, "Build Error!", e));
         } finally {
-            if (!buildLog.isEmpty())
+            if (buildLog.isActive())
                 logger.logInfo(buildLog.toString(myProject.getName(), files), null);
             listeners.release();
         }
@@ -389,6 +394,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
         if (buildFiles != null)
             for (File f : buildFiles)
                 IO.delete(f);
+        IO.delete(new File(model.getTarget(), Project.BUILDFILES));
     }
 
     private static IPath calculateTargetDirPath(Project model) throws Exception {

--- a/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
+++ b/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
@@ -71,4 +71,8 @@ public class BuildLogger {
 
         return top.append('\n').append(sb).toString();
     }
+
+    public boolean isActive() {
+        return level != LOG_NONE;
+    }
 }

--- a/bndtools.builder/src/org/bndtools/builder/MarkerSupport.java
+++ b/bndtools.builder/src/org/bndtools/builder/MarkerSupport.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.bndtools.api.BndtoolsConstants;
 import org.bndtools.api.ILogger;
 import org.bndtools.api.IValidator;
 import org.bndtools.api.Logger;
@@ -28,6 +27,7 @@ import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Processor;
 import aQute.service.reporter.Report.Location;
+import static org.bndtools.api.BndtoolsConstants.*;
 
 class MarkerSupport {
     private static final ILogger logger = Logger.getLogger(BndtoolsBuilder.class);
@@ -43,7 +43,7 @@ class MarkerSupport {
             if (containsError(dw, project.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE)))
                 return true;
 
-            if (containsError(dw, project.findMarkers(BndtoolsConstants.MARKER_BND_PATH_PROBLEM, true, IResource.DEPTH_INFINITE)))
+            if (containsError(dw, project.findMarkers(MARKER_BND_PATH_PROBLEM, true, IResource.DEPTH_INFINITE)))
                 return true;
 
             return false;
@@ -61,9 +61,9 @@ class MarkerSupport {
 
     void deleteMarkers(String markerType) throws CoreException {
         if (markerType.equals("*")) {
-            deleteMarkers(BndtoolsConstants.MARKER_BND_PROBLEM);
-            deleteMarkers(BndtoolsConstants.MARKER_BND_PATH_PROBLEM);
-            deleteMarkers(BndtoolsConstants.MARKER_BND_WORKSPACE_PROBLEM);
+            deleteMarkers(MARKER_BND_PROBLEM);
+            deleteMarkers(MARKER_BND_PATH_PROBLEM);
+            deleteMarkers(MARKER_BND_WORKSPACE_PROBLEM);
         } else
             project.deleteMarkers(markerType, true, IResource.DEPTH_INFINITE);
     }
@@ -90,7 +90,7 @@ class MarkerSupport {
             return;
         }
 
-        createMarker(model, iStatusSeverityToIMarkerSeverity(status), status.getMessage(), BndtoolsConstants.MARKER_BND_PROBLEM);
+        createMarker(model, iStatusSeverityToIMarkerSeverity(status), status.getMessage(), MARKER_BND_PROBLEM);
     }
 
     void createMarker(Processor model, int severity, String formatted, String markerType) throws Exception {
@@ -106,6 +106,18 @@ class MarkerSupport {
                     IMarker marker = resource.createMarker(markerType);
                     marker.setAttribute(IMarker.SEVERITY, severity);
                     marker.setAttribute("$bndType", type);
+
+                    //
+                    // Set location information
+                    if (location.header != null)
+                        marker.setAttribute(BNDTOOLS_MARKER_HEADER_ATTR, location.header);
+                    if (location.context != null)
+                        marker.setAttribute(BNDTOOLS_MARKER_CONTEXT_ATTR, location.context);
+                    if (location.file != null)
+                        marker.setAttribute(BNDTOOLS_MARKER_FILE_ATTR, location.file);
+                    if (location.reference != null)
+                        marker.setAttribute(BNDTOOLS_MARKER_REFERENCE_ATTR, location.reference);
+
                     marker.setAttribute(BuildErrorDetailsHandler.PROP_HAS_RESOLUTIONS, markerData.hasResolutions());
                     for (Entry<String,Object> attrib : markerData.getAttribs().entrySet())
                         marker.setAttribute(attrib.getKey(), attrib.getValue());
@@ -161,7 +173,7 @@ class MarkerSupport {
 
     static List<IValidator> loadValidators() {
         List<IValidator> validators = null;
-        IConfigurationElement[] validatorElems = Platform.getExtensionRegistry().getConfigurationElementsFor(BndtoolsConstants.CORE_PLUGIN_ID, "validators");
+        IConfigurationElement[] validatorElems = Platform.getExtensionRegistry().getConfigurationElementsFor(CORE_PLUGIN_ID, "validators");
         if (validatorElems != null && validatorElems.length > 0) {
             validators = new ArrayList<IValidator>(validatorElems.length);
             for (IConfigurationElement elem : validatorElems) {


### PR DESCRIPTION
– If a postponed build returned, the log said that nothing was build
– Markers now contain more Location info from bnd so we can pick it up in lists