### PR TITLE
gradle: Use method names for bnd types

### DIFF
--- a/build/build.gradle
+++ b/build/build.gradle
@@ -25,19 +25,19 @@ import org.apache.tools.ant.filters.ReplaceTokens
  * Copy the bundle outputs of the specified projects into a directory
  */
 void copyProjectBundles(String[] projs, String dstDir) {
+  def targetDir = file(dstDir)
+  if ((!targetDir.exists() && !targetDir.mkdirs()) || !targetDir.isDirectory()) {
+    throw new GradleException("Could not create directory $targetDir")
+  }
   projs.each {
     def proj = rootProject.findProject(it)
     if (proj == null) {
       throw new GradleException("Could not find project " + it)
     }
 
-    proj.bnd.project.subBuilders.each { subBuilder ->
-      def targetDir = file(dstDir)
-      if ((!targetDir.exists() && !targetDir.mkdirs()) || !targetDir.isDirectory()) {
-        throw new GradleException("Could not create directory $targetDir")
-      }
+    proj.bnd.project.getSubBuilders()*.getBsn().each { bsn ->
       copy {
-        from project.relativePath(proj.bnd.project.getOutputFile(subBuilder.bsn))
+        from project.relativePath(proj.bnd.project.getOutputFile(bsn))
         into targetDir
       }
     }
@@ -213,7 +213,7 @@ task('index') {
   group 'release'
 
   /* indexer */
-  def repoindexJar = bnd.project.getBundle('org.osgi.impl.bundle.repoindex.cli', 'latest', null, ['strategy':'highest']).file
+  def repoindexJar = bnd.project.getBundle('org.osgi.impl.bundle.repoindex.cli', 'latest', null, ['strategy':'highest']).getFile()
 
   /* Bundles to index. */
   def p2_index_main_bundles = fileTree("$buildDir/p2/plugins") {
@@ -233,7 +233,7 @@ task('index') {
 
   doLast {
     /* p2 main */
-    def bundlesToIndex = p2_index_main_bundles.collect { it.absolutePath }
+    def bundlesToIndex = p2_index_main_bundles*.absolutePath
     javaexec {
       main = '-jar' // first arg must be the jar
       args repoindexJar
@@ -245,7 +245,7 @@ task('index') {
     logger.info "Generated index ${p2_index_main}."
 
     /* p2 extras */
-    bundlesToIndex = p2_index_extras_bundles.collect { it.absolutePath }
+    bundlesToIndex = p2_index_extras_bundles*.absolutePath
     javaexec {
       main = '-jar' // first arg must be the jar
       args repoindexJar
@@ -291,4 +291,3 @@ task dist {
   group       'release'
   dependsOn index, distZipMain, distZipExtras
 }
-

--- a/org.bndtools.headless.build.plugin.gradle/resources/templates/unprocessed/root/settings.gradle
+++ b/org.bndtools.headless.build.plugin.gradle/resources/templates/unprocessed/root/settings.gradle
@@ -70,8 +70,8 @@ if (projectNames.remove('')) {
 projectNames.each { projectName ->
   include projectName
   def project = getBndProject(workspace, projectName)
-  project?.dependson.each {
-    include it.name
+  project?.getDependson()*.getName().each {
+    include it
   }
 }
 
@@ -88,10 +88,10 @@ def getBndProject(Workspace workspace, String projectName) {
 
   project.getInfo(workspace, "${rootDir} :")
   def errorCount = 0
-  project.warnings.each {
+  project.getWarnings().each {
     println "Warning: ${it}"
   }
-  project.errors.each {
+  project.getErrors().each {
     println "Error  : ${it}"
     errorCount++
   }

--- a/settings.gradle
+++ b/settings.gradle
@@ -85,8 +85,8 @@ if (projectNames.remove('')) {
 projectNames.each { projectName ->
   include projectName
   def project = getBndProject(workspace, projectName)
-  project?.dependson.each {
-    include it.name
+  project?.getDependson()*.getName().each {
+    include it
   }
 }
 
@@ -103,10 +103,10 @@ def getBndProject(Workspace workspace, String projectName) {
 
   project.getInfo(workspace, "${rootDir} :")
   def errorCount = 0
-  project.warnings.each {
+  project.getWarnings().each {
     println "Warning: ${it}"
   }
-  project.errors.each {
+  project.getErrors().each {
     println "Error  : ${it}"
     errorCount++
   }


### PR DESCRIPTION
Some bnd types have non-private fields with the "same" name as the
getter method. For example: sourcepath and getSourcepath. Groovy
was picking the field instead of the getter. This caused an error
when the impl details of the field changed while the method did not.
So we now always use method calls in the Groovy code to make sure we
always call the getter and not access the field.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>