### PR TITLE
Classpath check for upstream changes

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -59,7 +59,7 @@ import bndtools.preferences.CompileErrorAction;
  *  touch bar.bnd -> see if manifest is updated in JAR (Jar viewer does not refresh very well, so reopen)
  *  touch build.bnd -> verify rebuild
  *  touch bnd.bnd in test -> verify rebuild
- * 
+ *
  *  create project test.2, add -buildpath: test
  * </pre>
  */
@@ -176,7 +176,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
 
                 String changed = ""; // if empty, no change
                 String del = "";
-                if (checkClasspathContainerUpdate(myProject)) {
+                if (requestClasspathContainerUpdate()) {
                     changed += "Classpath container updated";
                     del = " & ";
                 }
@@ -347,18 +347,15 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
     }
 
     /**
-     * Check if the classpath has changed for this project.
+     * Request the classpath container be updated for this project.
      * <p>
      * The classpath container may have added errors to the model which the caller must check for.
      *
-     * @param project
-     *            The IProject to check and update the classpath container.
-     * @return {@code true} if the specified project has a bnd classpath container and the classpath was changed.
-     *         {@code false} if the specified project does not have a bnd classpath container or the classpath was not
-     *         changed.
+     * @return {@code true} if this project has a bnd classpath container and the classpath was changed. {@code false}
+     *         if this project does not have a bnd classpath container or the classpath was not changed.
      */
-    private boolean checkClasspathContainerUpdate(IProject project) throws CoreException {
-        IJavaProject javaProject = JavaCore.create(project);
+    private boolean requestClasspathContainerUpdate() throws CoreException {
+        IJavaProject javaProject = JavaCore.create(getProject());
         if (javaProject == null) {
             return false; // project is not a java project
         }

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -149,6 +149,11 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
                 setupChanged = true;
             }
 
+            if (!force && !setupChanged && suggestClasspathContainerUpdate()) {
+                buildLog.basic("Project classpath may need to be updated");
+                setupChanged = true;
+            }
+
             //
             // If we already know we are going to build, we
             // must handle the path errors. We make sure
@@ -344,6 +349,22 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
         }
 
         return false;
+    }
+
+    /**
+     * Check if the classpath container this project needs to be updated.
+     *
+     * @return {@code true} if this project has a bnd classpath container and a classpath update should be requested.
+     *         {@code false} if this project does not have a bnd classpath container or a classpath update does not need
+     *         to be requested.
+     */
+    private boolean suggestClasspathContainerUpdate() throws CoreException {
+        IJavaProject javaProject = JavaCore.create(getProject());
+        if (javaProject == null) {
+            return false; // project is not a java project
+        }
+
+        return BndContainerInitializer.suggestClasspathContainerUpdate(javaProject);
     }
 
     /**

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -144,7 +144,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
                 setupChanged = true && !postponed;
             }
 
-            if (!force && delta.hasEclipseChanged()) {
+            if (!force && !setupChanged && delta.hasEclipseChanged()) {
                 buildLog.basic("Eclipse project had a buildpath change");
                 setupChanged = true;
             }

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
@@ -6,12 +6,11 @@ import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 
 public class BndContainer implements IClasspathContainer {
+    public static final String DESCRIPTION = "Bnd Bundle Path";
     private final IClasspathEntry[] entries;
-    private final String description;
 
-    public BndContainer(IClasspathEntry[] entries, String description) {
+    BndContainer(IClasspathEntry[] entries) {
         this.entries = entries;
-        this.description = description;
     }
 
     @Override
@@ -21,7 +20,7 @@ public class BndContainer implements IClasspathContainer {
 
     @Override
     public String getDescription() {
-        return description;
+        return DESCRIPTION;
     }
 
     @Override

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -60,7 +60,6 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
     static final IClasspathEntry[] EMPTY_ENTRIES = new IClasspathEntry[0];
     static final IAccessRule DISCOURAGED = JavaCore.newAccessRule(new Path("**"), IAccessRule.K_DISCOURAGED);
     static final Pattern packagePattern = Pattern.compile("(?<=^|\\.)\\*(?=\\.|$)|\\.");
-    static final ReentrantLock bndLock = new ReentrantLock();
 
     /*
      * @GuardedBy bndLock
@@ -175,6 +174,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
             List<IClasspathEntry> newClasspath = Collections.emptyList();
             boolean interrupted = Thread.interrupted();
             try {
+                final ReentrantLock bndLock = Central.getBndLock();
                 if (bndLock.tryLock(5, TimeUnit.SECONDS)) {
                     try {
                         newClasspath = calculateProjectClasspath();

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -57,18 +57,9 @@ import bndtools.preferences.BndPreferences;
  */
 public class BndContainerInitializer extends ClasspathContainerInitializer implements ModelListener {
     static final ILogger logger = Logger.getLogger(BndContainerInitializer.class);
-    static final IClasspathEntry[] EMPTY_ENTRIES = new IClasspathEntry[0];
-    static final IAccessRule DISCOURAGED = JavaCore.newAccessRule(new Path("**"), IAccessRule.K_DISCOURAGED);
-    static final Pattern packagePattern = Pattern.compile("(?<=^|\\.)\\*(?=\\.|$)|\\.");
-
-    /*
-     * @GuardedBy bndLock
-     */
-    final Map<File,JarInfo> jarInfo;
 
     public BndContainerInitializer() {
         super();
-        jarInfo = new WeakHashMap<File,JarInfo>();
         Central.getInstance().addModelListener(this);
     }
 
@@ -76,7 +67,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
     public void initialize(IPath containerPath, IJavaProject javaProject) throws CoreException {
         IProject project = javaProject.getProject();
 
-        final Updater updater = new Updater(project, javaProject);
+        Updater updater = new Updater(project, javaProject);
         updater.updateClasspathContainer(true);
     }
 
@@ -142,7 +133,12 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
         }
     }
 
-    private class Updater {
+    private static class Updater {
+        private static final IClasspathEntry[] EMPTY_ENTRIES = new IClasspathEntry[0];
+        private static final IAccessRule DISCOURAGED = JavaCore.newAccessRule(new Path("**"), IAccessRule.K_DISCOURAGED);
+        private static final Pattern packagePattern = Pattern.compile("(?<=^|\\.)\\*(?=\\.|$)|\\.");
+        private static final Map<File,JarInfo> jarInfo = Collections.synchronizedMap(new WeakHashMap<File,JarInfo>());
+
         private final IProject project;
         private final IJavaProject javaProject;
         private final IWorkspaceRoot root;

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -98,7 +98,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 
     @Override
     public String getDescription(IPath containerPath, IJavaProject project) {
-        return "Bnd Bundle Path";
+        return BndContainer.DESCRIPTION;
     }
 
     /**
@@ -212,7 +212,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
             JavaCore.setClasspathContainer(BndtoolsConstants.BND_CLASSPATH_ID, new IJavaProject[] {
                 javaProject
             }, new IClasspathContainer[] {
-                new BndContainer(entries, getDescription(BndtoolsConstants.BND_CLASSPATH_ID, javaProject))
+                new BndContainer(entries)
             }, null);
 
             BndPreferences prefs = new BndPreferences();

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.bndtools.api.BndtoolsConstants;
 import org.bndtools.api.ILogger;
@@ -564,5 +565,14 @@ public class Central implements IStartupParticipant {
             return null;
 
         return ifiles[0];
+    }
+
+    /**
+     * Used to serialize access to bnd code which is not thread safe
+     */
+    private static final ReentrantLock bndLock = new ReentrantLock();
+
+    public static ReentrantLock getBndLock() {
+        return bndLock;
     }
 }


### PR DESCRIPTION
A can depend upon B. B can changes its exports. A's classpath needs to
be updated to reflects the new access rules. This fix will check if A's
dependencies have been updated and if so, suggest a classpath update
for A.
