### PR TITLE
classpath container: suggest container update needs to use a timestamp

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -358,7 +358,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
      *         {@code false} if this project does not have a bnd classpath container or a classpath update does not need
      *         to be requested.
      */
-    private boolean suggestClasspathContainerUpdate() throws CoreException {
+    private boolean suggestClasspathContainerUpdate() throws Exception {
         IJavaProject javaProject = JavaCore.create(getProject());
         if (javaProject == null) {
             return false; // project is not a java project

--- a/bndtools.builder/src/org/bndtools/builder/DeltaWrapper.java
+++ b/bndtools.builder/src/org/bndtools/builder/DeltaWrapper.java
@@ -64,12 +64,12 @@ class DeltaWrapper {
         delta.accept(new IResourceDeltaVisitor() {
 
             @Override
-            public boolean visit(IResourceDelta arg0) throws CoreException {
+            public boolean visit(IResourceDelta visitDelta) throws CoreException {
 
                 if ((delta.getKind() & (IResourceDelta.ADDED | IResourceDelta.CHANGED | IResourceDelta.REMOVED)) == 0)
                     return false;
 
-                IResource resource = arg0.getResource();
+                IResource resource = visitDelta.getResource();
                 if (resource.getType() == IResource.ROOT || resource.getType() == IResource.PROJECT)
                     return true;
 

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
@@ -8,9 +8,11 @@ import org.eclipse.jdt.core.IClasspathEntry;
 public class BndContainer implements IClasspathContainer {
     public static final String DESCRIPTION = "Bnd Bundle Path";
     private final IClasspathEntry[] entries;
+    private volatile long lastModified;
 
-    BndContainer(IClasspathEntry[] entries) {
+    BndContainer(IClasspathEntry[] entries, long lastModified) {
         this.entries = entries;
+        this.lastModified = lastModified;
     }
 
     @Override
@@ -36,5 +38,15 @@ public class BndContainer implements IClasspathContainer {
     @Override
     public String toString() {
         return getDescription();
+    }
+
+    public long lastModified() {
+        return lastModified;
+    }
+
+    public synchronized void updateLastModified(long time) {
+        if (time > lastModified) {
+            lastModified = time;
+        }
     }
 }


### PR DESCRIPTION
The old impl uses the JarInfo cache, but updating one container will
update the cache so that a later container would not see that it needed
to be updated. So now we hold a lastModified timestamp in the container
that holds the timestamp of the newest item in the container. The
suggest change method will compare the timestamp of the container to the
timestamps of the container items and suggest an update if any item is
newer than the container timestamp.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>