### PR TITLE
classpath: No access rules for empty persisted access patterns

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -525,8 +525,10 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
                 }
                 String[] patterns = oldAccessPatterns.split(",");
                 List<IAccessRule> accessRules = new ArrayList<IAccessRule>(patterns.length);
-                for (String pathStr : patterns) {
-                    accessRules.add(JavaCore.newAccessRule(new Path(pathStr), IAccessRule.K_ACCESSIBLE));
+                if (!oldAccessPatterns.isEmpty()) { // if not empty, there are access patterns
+                    for (String pathStr : patterns) {
+                        accessRules.add(JavaCore.newAccessRule(new Path(pathStr), IAccessRule.K_ACCESSIBLE));
+                    }
                 }
                 return accessRules;
             }


### PR DESCRIPTION
If an empty string was persisted as the access patterns for a project,
an access rule with the path of the empty string was mistakenly created.
This causes eclipse to throw an exception:
https://bugs.eclipse.org/465640

Fixes https://github.com/bndtools/bndtools/issues/1108

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>