### PR TITLE
Correct FQCN for RemoveRepoResourceHandler

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -231,7 +231,7 @@
    <extension point="org.eclipse.ui.handlers">
       <handler
          commandId="bndtools.core.removeRepoResource"
-         class="bndtools.views.RemoveRepoResourceHandler">
+         class="bndtools.views.repository.RemoveRepoResourceHandler">
          <enabledWhen>
             <with variable="selection">
                <count value="+" />


### PR DESCRIPTION
This resolves a "The proxied handler for
'bndtools.views.RemoveRepoResourceHandler' could not be loaded" error
when right-clicking on JPM resources in the Repositories view.

Signed-off-by: Sean Bright <sean@malleable.com>