### PR TITLE
Update DS annotation option text to reflect 1.3

### DIFF
--- a/bndtools.core/src/bndtools/editor/contents/GeneralInfoPart.java
+++ b/bndtools.core/src/bndtools/editor/contents/GeneralInfoPart.java
@@ -88,7 +88,7 @@ public class GeneralInfoPart extends SectionPart implements PropertyChangeListen
     };
 
     private static enum ComponentChoice {
-        None("None/Undefined"), Bnd("Bnd Annotations"), DS("DS 1.2 Annotations");
+        None("None/Undefined"), Bnd("Bnd Annotations"), DS("OSGi DS Annotations");
 
         private final String label;
 


### PR DESCRIPTION
Not in love with this, but with 1.3 generally available it is a bit more
clear about capabilities.

Signed-off-by: Sean Bright <sean@malleable.com>