### PR TITLE
Don't run the resolver if there is no point

### DIFF
--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -246,6 +246,10 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 
     private final AtomicBoolean saving = new AtomicBoolean(false);
 
+    private boolean shouldAutoResolve() {
+        return getResolveMode() == ResolveMode.auto && !model.getRunRequires().isEmpty() && !PlatformUI.getWorkbench().isClosing();
+    }
+
     @Override
     public void doSave(IProgressMonitor monitor) {
         final Shell shell = getEditorSite().getShell();
@@ -258,10 +262,8 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
             sourcePage.refresh();
         }
 
-        ResolveMode resolveMode = getResolveMode();
-
         // If auto resolve, then resolve and save in background thread.
-        if (resolveMode == ResolveMode.auto && !PlatformUI.getWorkbench().isClosing()) {
+        if (shouldAutoResolve()) {
             final IFile file = ResourceUtil.getFile(getEditorInput());
             if (file == null) {
                 MessageDialog.openError(shell, "Resolution Error", "Unable to run resolution because the file is not in the workspace. NB.: the file will still be saved.");

--- a/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
@@ -269,6 +269,7 @@ public class RunRequirementsPart extends SectionPart implements PropertyChangeLi
                     requires.addAll(adding);
                     viewer.add(adding.toArray(new Object[adding.size()]));
                     markDirty();
+                    updateButtonStates();
                 }
             }
         } catch (Exception e) {
@@ -291,6 +292,7 @@ public class RunRequirementsPart extends SectionPart implements PropertyChangeLi
             if (!removed.isEmpty()) {
                 viewer.remove(removed.toArray(new Object[removed.size()]));
                 markDirty();
+                updateButtonStates();
             }
         }
     }
@@ -453,7 +455,7 @@ public class RunRequirementsPart extends SectionPart implements PropertyChangeLi
     }
 
     private void updateButtonStates() {
-        // btnResolveNow.setEnabled(resolveMode != ResolveMode.auto);
+        btnResolveNow.setEnabled(!requires.isEmpty());
     }
 
     @Override
@@ -492,6 +494,7 @@ public class RunRequirementsPart extends SectionPart implements PropertyChangeLi
                 requires.addAll(adding);
                 viewer.add(adding.toArray(new Object[adding.size()]));
                 markDirty();
+                updateButtonStates();
                 return true;
             }
             return false;


### PR DESCRIPTION
This disables the 'Resolve' button if we have an empty list of Run Requiments and also checks on save (if auto resolve is enabled) before running the resolver.