### PR TITLE
Avoid tripping up when creating error markers

### DIFF
--- a/bndtools.core/src/org/bndtools/build/api/AbstractBuildErrorDetailsHandler.java
+++ b/bndtools.core/src/org/bndtools/build/api/AbstractBuildErrorDetailsHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.PrimitiveType;
 import org.eclipse.jdt.core.dom.PrimitiveType.Code;
 import org.eclipse.jdt.core.dom.QualifiedType;
@@ -219,6 +220,10 @@ public abstract class AbstractBuildErrorDetailsHandler implements BuildErrorDeta
                         }
                         //We still need to add the array component type, which might be primitive or a reference
                         rovingType = type.getElementType();
+                    }
+                    // Type erasure means that we should ignore parameters
+                    if (rovingType.isParameterizedType()) {
+                        rovingType = ((ParameterizedType) rovingType).getType();
                     }
 
                     if (rovingType.isPrimitiveType()) {


### PR DESCRIPTION
The error marker search code didn't handle Parameterized types as method parameters, and threw an IllegalStateException. As the paramterization is erased from the signature we should just use the SimpleType without the paramaters. Fixes #1215

Signed-off-by: Tim Ward <timothyjward@apache.org>