### PR TITLE
1160: use Eclipse-Job-API for repository actions

### DIFF
--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -71,7 +71,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.ui.ISharedImages;
@@ -85,7 +84,6 @@ import org.eclipse.ui.part.ResourceTransfer;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.resource.Requirement;
-
 
 import aQute.bnd.service.Actionable;
 import aQute.bnd.service.Refreshable;
@@ -630,12 +628,8 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
                                                         if (rp != null && rp instanceof Refreshable)
                                                             Central.refreshPlugin((Refreshable) rp);
                                                     } catch (final Exception e) {
-                                                        Display.getDefault().asyncExec(new Runnable() {
-                                                            @Override
-                                                            public void run() {
-                                                                MessageDialog.openError(PlatformUI.getWorkbench().getModalDialogShellProvider().getShell(), "Error executing: " + getName(), e.getMessage());
-                                                            }
-                                                        });
+                                                        IStatus status = new Status(IStatus.ERROR, Plugin.getDefault().getBundle().getSymbolicName(), "Error executing: " + getName(), e);
+                                                        Plugin.getDefault().getLog().log(status);
                                                     }
                                                     monitor.done();
                                                     return Status.OK_STATUS;

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -648,7 +648,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
                                                     if (event.getResult().isOK()) {
                                                         viewer.refresh();
                                                     }
-                                                };
+                                                }
                                             });
 
                                             backgroundJob.setUser(true);

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -629,7 +629,6 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
                                                         e.getValue().run();
                                                         if (rp != null && rp instanceof Refreshable)
                                                             Central.refreshPlugin((Refreshable) rp);
-                                                        Thread.currentThread().sleep(10000);
                                                     } catch (final Exception e) {
                                                         Display.getDefault().asyncExec(new Runnable() {
                                                             @Override


### PR DESCRIPTION
To give the user some visual feedback for long running
repository-actions (e.g. "Download All") the Runnable is wrapped with
the Eclipse-Job-API.

This will only give the user feedback that there is a job running and when it is done. 
In order to add more feedback with a progressbar the bnd-side must be enhanced with some other interface than Runnable (maybe some simple callback-interface which reveives an int for the current status).

Signed-off-by: Marc Schlegel <maschlegel@gmail.com>