### PR TITLE
build: Add support for relative file urls to the bnd gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ ext.bndWorkspace = new Workspace(rootDir, bnd_cnf)
 if (bndWorkspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }
-/* Set this property in the workspace. It may have been set on the command line with -P */
-bndWorkspace.setProperty('bnd_repourl', bnd_repourl)
+/* Set this property in the workspace */
+bndWorkspace.setProperty('bnd_repourl', uri(bnd_repourl).toString())
 
 ext.cnf = rootProject.project(bnd_cnf)
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ import aQute.bnd.osgi.Constants
 buildscript {
   repositories {
     ivy { /* Configure the repository as an "ivy" repository */
-      url bnd_repourl
+      url uri(bnd_repourl)
       layout 'pattern', {
             artifact '[module]/[artifact]-[revision].[ext]' /* OSGi repo pattern */
             artifact '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])' /* maven pattern */
@@ -44,6 +44,7 @@ def workspace = new Workspace(rootDir, bnd_cnf)
 if (workspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }
+workspace.setProperty('bnd_repourl', uri(bnd_repourl).toString())
 
 /* Add cnf project to the graph */
 include bnd_cnf


### PR DESCRIPTION
We use the gradle uri method.

However, you still need to use absolute urls in the gradle.properties
file since that file is included in bndtools(Eclipse) and bnd has no
provision to resolve the relative uri.