### PR TITLE
uri: Use new uri macro to allow relative path to local bnd build

### DIFF
--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -6,7 +6,7 @@ eclipse-repo: aQute.bnd.deployer.repository.FixedIndexedRepo; name="Eclipse IDE 
 #
 # Bnd Repository. See ${workspace}/gradle.properties for the bnd_repourl property.
 #
-bndRepo: ${bnd_repourl}/index.xml.gz
+bndRepo: ${uri;${bnd_repourl}}/index.xml.gz
 
 #
 # Don't touch below

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,13 @@ bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:latest
 # The URL to the bnd build repo. 
 # DO NOT check in changes to this. This can be overridden on the gradle command line with
 # -Pbnd_repourl=...
-# This allows the value to be externally set in the CI build.
 bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.master/lastSuccessfulBuild/artifact/dist/bundles
 
 # Repo URL to build against bnd.next
 #bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.next/lastSuccessfulBuild/artifact/dist/bundles
-# Repo URL to build against local bnd repo build. You will need to set the absolute path to the local
-# bnd repo build. Pushing a local repo url to github WILL break the build.
-#bnd_repourl=file:///path-to-bnd-repo/dist/bundles
+
+# Repo URL to build against local bnd repo build. Pushing a local repo url to github WILL break the build.
+#bnd_repourl=../bnd/dist/bundles
 
 # bnd_build can be set to the name of a "master" project whose dependencies will seed the set of projects to build.
 bnd_build=build

--- a/rebuild-with-local-plugin
+++ b/rebuild-with-local-plugin
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+## Rebuild using the locally built bnd gradle plugin from ../bnd
+##
+##############################################################################
+REPO=$(dirname ${BASH_SOURCE[0]})
+BND=../bnd
+ARGS="$@"
+if [ -z "$ARGS" ]; then
+  ARGS="--rerun-tasks"
+fi
+
+echo $REPO/gradlew --no-daemon -Pbnd_repourl=$REPO/$BND/dist/bundles $ARGS
+$REPO/gradlew --no-daemon -Pbnd_repourl=$REPO/$BND/dist/bundles $ARGS


### PR DESCRIPTION
You can now set bnd_repourl=../bnd/dist/bundles in gradle.properties to
build against your local bnd build.

Add rebuild script to test build with local build of bnd gradle plugin.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>