### PR TITLE
templates: The template projects are not part of the bndtools feature

### DIFF
--- a/bndtools.manual/developer/RELEASE_CHECKLIST.md
+++ b/bndtools.manual/developer/RELEASE_CHECKLIST.md
@@ -84,12 +84,12 @@ git push origin master a.b.c.REL
 for the build to finish and be successful.
 * Lock the Cloudbees build so that it is kept forever, and set the build information to
 `Bndtools a.b.c.REL`
-* Download a ZIP file with the relevant archived artifacts from
-https://bndtools.ci.cloudbees.com/job/bndtools.master/lastSuccessfulBuild/artifact/build/generated/bndtools-latest.zip
+* Download the ZIP file [bndtools-latest.zip][5] from Cloudbees.
 * Create a new a.b.c version in [Bintray][1].
 * Unpack the ZIP file and store the contents in the a.b.c version at [Bintray][1].
 * Also update the latest version at [Bintray][1] with the content of the ZIP file.
-* Add the `org.bndtools.templates.*` bundles from the ZIP file to [Bundle-hub][3].
+* Add the `org.bndtools.templates.*` bundles from the [release repo][4] on Cloudbees
+to [Bundle-hub][3].
 
 * Update the versions for the next development cycle in the file `cnf/build.bnd`:
 
@@ -111,3 +111,5 @@ git push origin master a.d.0.DEV
 [1]: https://bintray.com/bndtools/bndtools/update/view
 [2]: https://bndtools.ci.cloudbees.com/
 [3]: https://github.com/bndtools/bundle-hub
+[4]: https://bndtools.ci.cloudbees.com/job/bndtools.master/lastSuccessfulBuild/artifact/build/releaserepo/
+[5]: https://bndtools.ci.cloudbees.com/job/bndtools.master/lastSuccessfulBuild/artifact/build/generated/bndtools-latest.zip

--- a/build/bnd.bnd
+++ b/build/bnd.bnd
@@ -18,8 +18,11 @@ p2 = bndtools.api, \
     org.bndtools.headless.build.plugin.gradle, \
     org.bndtools.versioncontrol.ignores.manager, \
     org.bndtools.versioncontrol.ignores.plugin.git, \
-    org.bndtools.templating, \
+    org.bndtools.templating
+
+# Template projects which are not part of the p2 feature
+templates = \
     org.bndtools.templates.osgi, \
     org.bndtools.templates.template
 
--dependson: ${p2}
+-dependson: ${p2}, ${templates}

--- a/build/feature/bndtools/feature.xml
+++ b/build/feature/bndtools/feature.xml
@@ -228,20 +228,6 @@ This Agreement is governed by the laws of the State of New York and the intellec
          unpack="false"/>
 
    <plugin
-         id="org.bndtools.templates.osgi"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.bndtools.templates.template"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="javax.xml"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Bndtools references the templates from a repo rather than installed
plugins. So the template bundles are not part of the p2 feature for
Bndtools.