### PR TITLE
Use ${junit} in -testpath of DS template

### DIFF
--- a/org.bndtools.templates.osgi/resources/templates/ds/bnd.bnd
+++ b/org.bndtools.templates.osgi/resources/templates/ds/bnd.bnd
@@ -4,8 +4,7 @@
 	osgi.cmpn; version=6.0
 
 -testpath: \
-	junit; version=4,\
-	hamcrest-core; version=1.3
+	\${junit}
 
 Bundle-Version: 0.0.0.\${tstamp}
 Private-Package: $basePackageName$


### PR DESCRIPTION
This fixes a testpath error when creating a project from the Component
Development template when your cnf project is created using the JPM4J
Configuration.

Signed-off-by: Sean Bright <sean.bright@gmail.com>