### PR TITLE
build: Use SPDX license identifier for Bundle-License header

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -110,7 +110,7 @@ Bundle-Version:           ${build.version}
 Bundle-Vendor:            Bndtools http://bndtools.org/
 copyright:				  Copyright (c) Neil Bartlett (2009, ${tstamp;yyyy}) and others. All Rights Reserved.
 Bundle-Copyright:         ${copyright}
-Bundle-License:           http://opensource.org/licenses/EPL-1.0; \
+Bundle-License:           EPL-1.0; \
                           description="Eclipse Public License, Version 1.0"; \
                           link="http://www.eclipse.org/legal/epl-v10.html"
 Bundle-DocURL:            http://bndtools.org/


### PR DESCRIPTION
Signed-off-by: BJ Hargrave <bj@bjhargrave.com>