### PR TITLE
build: A fix to bnd seems to have surfaced a bug in the build

### DIFF
--- a/bndtools.api/bnd.bnd
+++ b/bndtools.api/bnd.bnd
@@ -2,8 +2,8 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
-	osgi.core;version=${osgi.core.version}, \
 	${bndlib}, \
+	osgi.core;version=${osgi.core.version}, \
 	org.eclipse.equinox.common, \
 	org.eclipse.core.runtime
 

--- a/bndtools.builder/bnd.bnd
+++ b/bndtools.builder/bnd.bnd
@@ -2,10 +2,13 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath:  \
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
 	${bndlib};packages=*,\
 	${aQute-repository};packages=*,\
+	bndtools.api;version=latest,\
+	bndtools.utils;version=project;packages=*,\
+	bndtools.core;version=snapshot, \
+	osgi.core;version=${osgi.core.version},\
+	osgi.cmpn;version=${osgi.cmpn.version},\
 	javax.xml,\
 	org.eclipse.osgi,\
 	org.eclipse.equinox.common,\
@@ -25,10 +28,7 @@
 	org.eclipse.jdt.launching,\
 	org.eclipse.jdt.ui,\
 	org.eclipse.swt.cocoa.macosx.x86_64;packages=*,\
-	org.eclipse.swt,\
-	bndtools.api;version=latest,\
-	bndtools.utils;version=project;packages=*,\
-	bndtools.core;version=snapshot
+	org.eclipse.swt
 
 # Headers
 Bundle-SymbolicName: bndtools.builder; singleton:=true

--- a/bndtools.core/bnd.bnd
+++ b/bndtools.core/bnd.bnd
@@ -86,11 +86,11 @@ eclipse.deps: \
 	org.eclipse.core.contenttype
 
 -buildpath: \
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
 	${bndlib},\
 	${aQute-repository},\
 	${aQute-resolve},\
+	osgi.core;version=${osgi.core.version},\
+	osgi.cmpn;version=${osgi.cmpn.version},\
 	${eclipse.deps},\
 	javax.xml,\
 	javax.xml.stream,\

--- a/bndtools.jareditor/bnd.bnd
+++ b/bndtools.jareditor/bnd.bnd
@@ -5,8 +5,8 @@ Bundle-SymbolicName: bndtools.jareditor;singleton:=true
 Include-Resource: resources
 
 -buildpath:  \
-	osgi.core;version=${osgi.core.version},\
 	${bndlib},\
+	osgi.core;version=${osgi.core.version},\
 	org.eclipse.jface.text,\
 	org.eclipse.core.resources,\
 	org.eclipse.ui.editors,\

--- a/bndtools.release/bnd.bnd
+++ b/bndtools.release/bnd.bnd
@@ -23,12 +23,12 @@ Include-Resource: 	plugin.xml=_plugin.xml,\
 					/=resources
 
 -buildpath:\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
 	${bndlib},\
 	bndtools.utils;version=project;packages=*,\
 	bndtools.api;version=latest, \
 	bndtools.core;version=latest, \
+	osgi.core;version=${osgi.core.version},\
+	osgi.cmpn;version=${osgi.cmpn.version},\
 	org.eclipse.core.runtime,\
 	org.eclipse.core.contenttype,\
 	org.eclipse.jface,\

--- a/bndtools.utils/bnd.bnd
+++ b/bndtools.utils/bnd.bnd
@@ -2,9 +2,10 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
-    osgi.core;version=${osgi.core.version},\
-    osgi.cmpn;version=${osgi.cmpn.version},\
     ${bndlib}, \
+    bndtools.api; version=latest, \
+    osgi.core;version=${osgi.core.version}, \
+    osgi.cmpn;version=${osgi.cmpn.version}, \
     org.eclipse.osgi, \
     org.eclipse.equinox.common, \
     org.eclipse.equinox.registry, \
@@ -18,8 +19,7 @@
     org.eclipse.ui.ide, \
     org.eclipse.ui.workbench, \
     org.eclipse.jdt.core, \
-    org.eclipse.text, \
-    bndtools.api; version=latest
+    org.eclipse.text
     
 -testpath: \
     ${junit}

--- a/org.bndtools.headless.build.plugin.ant/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.ant/bnd.bnd
@@ -2,12 +2,12 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
-	osgi.core;version=${osgi.core.version},\
+	${bndlib},\
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
 	bndtools.utils;version=project;packages=*,\
 	biz.aQute.bnd.annotation,\
-	${bndlib}
+	osgi.core;version=${osgi.core.version}
 
 -testpath: \
 	${junit}

--- a/org.bndtools.headless.build.plugin.gradle/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.gradle/bnd.bnd
@@ -2,13 +2,13 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
-	osgi.core;version=${osgi.core.version},\
+	${bndlib},\
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
 	org.bndtools.versioncontrol.ignores.manager;version=latest,\
 	bndtools.utils;version=project;packages=*,\
 	biz.aQute.bnd.annotation,\
-	${bndlib},\
+	osgi.core;version=${osgi.core.version},\
 	${junit}
 -includeresource: \
 	templates=resources/templates/unprocessed, \

--- a/org.bndtools.templating/bnd.bnd
+++ b/org.bndtools.templating/bnd.bnd
@@ -2,11 +2,11 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath:\
+	${bndlib},\
+	${aQute-repository},\
 	osgi.core; version=${osgi.core.version},\
 	osgi.cmpn; version=${osgi.cmpn.version},\
 	org.eclipse.equinox.common,\
-	${bndlib},\
-	${aQute-repository},\
 	ST4-4.0.8-complete.jar; version=file
 -testpath: \
 	${junit}


### PR DESCRIPTION
bndlib includes the latest DS annotations and the -buildpaths of
projects has osgi.cmpn;5 before bndlib which caused a failure in
DS annotation processing during a test. We now always put bndlib before
osgi jars in the -buildpath.