### PR TITLE
#1332 OSGi enRoute workspace: cnf ends up in the Eclipse workspace

### DIFF
--- a/bndtools.core/src/bndtools/wizards/workspace/WorkspacePreviewPage.java
+++ b/bndtools.core/src/bndtools/wizards/workspace/WorkspacePreviewPage.java
@@ -1,9 +1,12 @@
 package bndtools.wizards.workspace;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,6 +50,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 
+import aQute.lib.io.IO;
 import bndtools.Plugin;
 import bndtools.utils.ModificationLock;
 
@@ -97,7 +101,8 @@ public class WorkspacePreviewPage extends WizardPage {
                                     resourceErrors.put(entry.getKey(), String.format("Path already exists and is not a directory: %s", entry.getKey()));
                                 break;
                             case File :
-                                if (file.exists()) {
+                                if (file.exists() && !isEqualContent(file, entry.getValue().getContent())) {
+
                                     existingFiles.add(entry.getKey());
                                     if (!file.isFile())
                                         resourceErrors.put(entry.getKey(), String.format("Path already exists and is not a plain file: %s", entry.getKey()));
@@ -133,6 +138,7 @@ public class WorkspacePreviewPage extends WizardPage {
 
             SWTConcurrencyUtil.execForControl(tblOutputs, true, updateDisplayTask);
         }
+
     };
 
     private final Runnable updateDisplayTask = new Runnable() {
@@ -402,4 +408,9 @@ public class WorkspacePreviewPage extends WizardPage {
         return Collections.unmodifiableSet(checkedPaths);
     }
 
+    private boolean isEqualContent(File file, InputStream content) throws IOException {
+        byte[] a = IO.read(file);
+        byte[] b = IO.read(content);
+        return Arrays.equals(a, b);
+    }
 }

--- a/bndtools.core/src/bndtools/wizards/workspace/WorkspaceSetupWizardPage.java
+++ b/bndtools.core/src/bndtools/wizards/workspace/WorkspaceSetupWizardPage.java
@@ -43,7 +43,7 @@ public class WorkspaceSetupWizardPage extends WizardPage {
 
     @Override
     public void createControl(Composite parent) {
-        setTitle("Setup Bnd/OSGi Workspace");
+        setTitle("Setup bnd Workspace");
         setDescription("Create a workspace folder with initial configuration");
         setImageDescriptor(Plugin.imageDescriptorFromPlugin("icons/bndtools-wizban.png")); //$NON-NLS-1$
 

--- a/bndtools.test/bndws/test.baseline/bnd.bnd
+++ b/bndtools.test/bndws/test.baseline/bnd.bnd
@@ -1,4 +1,4 @@
-Bundle-Version: 2.3.4.${tstamp}
+Bundle-Version: 2.3.5.${tstamp}
 Export-Package: \
 	test.baseline
 

--- a/bndtools.test/bndws/test.baseline/src/test/baseline/package-info.java
+++ b/bndtools.test/bndws/test.baseline/src/test/baseline/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.2.3")
+@Version("1.2.4")
 package test.baseline;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
The current code seemed quite confused about another directory for the 
bnd workspace from the Eclipse workspace. It gave a warning if the cnf
already existed but created a mess if this warning was ignored.

The changes are:

- Different UI for an update and create. For an update, you 
  cannot change the location of the cnf project anymore.
- Attempt to properly handle the bnd workspace when it is 
  in a different location. The cnf project will now get the 
  proper location
- If it is an update, files that are actually identical are not
  marked red. This is a binary compare. (It would be nice if
  we actually could use the Eclipse diff if there is a difference.)