### PR TITLE
build: Use Eclipse Orbit slf4j api bundle to avoid conflict

### DIFF
--- a/build/feature/bndtools/feature.xml
+++ b/build/feature/bndtools/feature.xml
@@ -235,17 +235,10 @@ This Agreement is governed by the laws of the State of New York and the intellec
          unpack="false"/>
 
    <plugin
-         id="slf4j.api"
+         id="org.slf4j.api"
          download-size="0"
          install-size="0"
-         version="@slf4j.api-version@"
-         unpack="false"/>
-
-   <plugin
-         id="slf4j.simple"
-         download-size="0"
-         install-size="0"
-         version="@slf4j.simple-version@"
+         version="@org.slf4j.api-version@"
          unpack="false"/>
 
    <plugin

--- a/build/main.bnd
+++ b/build/main.bnd
@@ -5,7 +5,6 @@
     ${repo;org.osgi.impl.bundle.repoindex.lib;${bnd-version-base}},\
     ${repo;biz.aQute.repository;${bnd-version-base}},\
     ${repo;biz.aQute.resolve;${bnd-version-base}},\
-    ${repo;slf4j.api;latest},\
-    ${repo;slf4j.simple;latest},\
+    ${repo;org.slf4j.api;latest},\
     ${repo;javax.xml;latest},\
     ${repo;javax.xml.stream;latest}

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -1,7 +1,12 @@
 #
 # Eclipse Repository. Eclipse 4.4.2
 #
-eclipse-repo: aQute.bnd.deployer.repository.FixedIndexedRepo; name="Eclipse IDE for Eclipse Committers 4.4.2"; locations=https://dl.bintray.com/bndtools/eclipse-repo/4.4.2/index.xml.gz
+eclipse-repo: aQute.bnd.deployer.repository.FixedIndexedRepo;\
+ name="Eclipse IDE for Eclipse Committers 4.4.2";\
+ locations=https://dl.bintray.com/bndtools/eclipse-repo/4.4.2/index.xml.gz
+eclipse-orbit: aQute.bnd.deployer.repository.FixedIndexedRepo;\
+ name="Eclipse Orbit 4.4.2";\
+ locations=http://download.eclipse.org/tools/orbit/downloads/drops/R20150124073747/repository/index.xml.gz
 
 #
 # Bnd Repository. See ${workspace}/gradle.properties for the bnd_repourl property.
@@ -34,6 +39,7 @@ jpm:\
 	,\
 	${jpm},\
 	${eclipse-repo},\
+	${eclipse-orbit},\
 	aQute.bnd.deployer.repository.LocalIndexedRepo; \
 		name='Release'; \
 		local=${workspace}/build/releaserepo; \


### PR DESCRIPTION
Eclipse Orbit, in its infinite wisdom, chose a different BSN for the
slf4j.api bundle than SLF4J did in the jar in Maven Central. So other
Eclipse features use the bundle from Orbit which seems to conflict with
the one from maven. So we change to package the bundle from Orbit.

Fixes https://github.com/bndtools/bndtools/issues/1371