### PR TITLE
Revert "[progress] Add BndProgress to build"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@
  */
 
 import aQute.bnd.build.Workspace
-import aQute.bnd.gradle.BndProgress
 import aQute.bnd.osgi.Constants
 
 /* Add bnd gradle plugin as a script dependency */
@@ -20,7 +19,6 @@ buildscript {
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
 ext.bndWorkspace = new Workspace(rootDir, bnd_cnf)
-ext.bndWorkspace.addBasicPlugin(new BndProgress(gradle))
 if (bndWorkspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,6 @@
  */
 
 import aQute.bnd.build.Workspace
-import aQute.bnd.gradle.BndProgress
 import aQute.bnd.osgi.Constants
 
 /* Add bnd gradle plugin as a script dependency */
@@ -43,7 +42,6 @@ buildscript {
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
 def workspace = new Workspace(rootDir, bnd_cnf)
-workspace.addBasicPlugin(new BndProgress(gradle))
 if (workspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }


### PR DESCRIPTION
Reverts bndtools/bndtools#1414

BndProgess uses Gradle internal API. We must not do this in the official Gradle plugin. We risk breaking badly when people upgrade Gradle.