### PR TITLE
container: Cannot defer initialization of bnd classpath container

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -75,6 +75,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 
     @Override
     public void initialize(IPath containerPath, final IJavaProject javaProject) throws CoreException {
+        Updater.emptyClasspathEntries(javaProject); // We must initialize the container when this method is called
         Central.onWorkspaceInit(new Function<Workspace,Void>() {
             @Override
             public Void apply(Workspace a) {
@@ -271,6 +272,14 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
                 }
             }
             return false;
+        }
+
+        static void emptyClasspathEntries(IJavaProject javaProject) throws JavaModelException {
+            JavaCore.setClasspathContainer(BndtoolsConstants.BND_CLASSPATH_ID, new IJavaProject[] {
+                    javaProject
+            }, new IClasspathContainer[] {
+                    new BndContainer(EMPTY_ENTRIES, 0L)
+            }, null);
         }
 
         private void setClasspathEntries(IClasspathEntry[] entries) throws JavaModelException {


### PR DESCRIPTION
The change to defer the initialization of the bnd class path container
to after the bnd workspace is initialized can result in the failure to
establish the bnd class path container for a java project. When
initialize is called by Eclipse, the code must call setClasspathContainer
otherwise Eclipse will decide the java project does not have a bnd
class path container. So we always start by calling setClasspathContainer
to set an empty class path and establish the bnd class path container.
Then, after the bnd workspace is initialized, we are called again and
will set the actual class path for the container.