### PR TITLE
Attempt to get eclipse to find sources of jars in external repositories

### DIFF
--- a/bndtools.core/src/bndtools/launch/BndDependencySourceContainer.java
+++ b/bndtools.core/src/bndtools/launch/BndDependencySourceContainer.java
@@ -17,6 +17,7 @@ import org.eclipse.debug.core.sourcelookup.ISourceContainerType;
 import org.eclipse.debug.core.sourcelookup.ISourceLookupDirector;
 import org.eclipse.debug.core.sourcelookup.containers.ArchiveSourceContainer;
 import org.eclipse.debug.core.sourcelookup.containers.CompositeSourceContainer;
+import org.eclipse.debug.core.sourcelookup.containers.ExternalArchiveSourceContainer;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.sourcelookup.containers.JavaProjectSourceContainer;
@@ -79,12 +80,16 @@ public class BndDependencySourceContainer extends CompositeSourceContainer {
                         }
                     } else if (runbundle.getType() == TYPE.REPO) {
                         IPath bundlePath = Central.toPath(runbundle.getFile());
+                        IFile bundleFile = null;
                         if (bundlePath != null) {
-                            IFile bundleFile = ResourcesPlugin.getWorkspace().getRoot().getFile(bundlePath);
-                            if (bundleFile != null) {
-                                ArchiveSourceContainer tempArchiveCont = new ArchiveSourceContainer(bundleFile, false);
-                                result.add(tempArchiveCont);
-                            }
+                            bundleFile = ResourcesPlugin.getWorkspace().getRoot().getFile(bundlePath);
+                        }
+                        if (bundleFile != null) {
+                            ArchiveSourceContainer tempArchiveCont = new ArchiveSourceContainer(bundleFile, false);
+                            result.add(tempArchiveCont);
+                        } else {
+                            ExternalArchiveSourceContainer container = new ExternalArchiveSourceContainer(runbundle.getFile().toString(), false);
+                            result.add(container);
                         }
                     }
                 }


### PR DESCRIPTION
Previously the code appeared to try and convert the external file path into a workspace path
before creating an AcrhiveSourceContainer object.
This just, rather naively, directly constructs an ExternalArchiveSourceContainer pointing at the
bundle jar.

It appears to fix the issue of finding source for external libraries. If you have, say, downloaded
a bundle from Central, and added source, then source will now be found. Previously it appeared
that source was only found for bundles in Local, as only then was the jar file actually in the workspace.

Signed-off-by: Tom Quarendon <tom@quarendon.net>