### PR TITLE
classpath container: Serialize to allow restore before workspace init

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
@@ -1,5 +1,6 @@
 package org.bndtools.builder.classpath;
 
+import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.bndtools.api.BndtoolsConstants;
@@ -7,7 +8,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 
-public class BndContainer implements IClasspathContainer {
+public class BndContainer implements IClasspathContainer, Serializable {
+    private static final long serialVersionUID = 1L;
     public static final String DESCRIPTION = "Bnd Bundle Path";
     private final IClasspathEntry[] entries;
     private final AtomicLong lastModified;
@@ -46,11 +48,12 @@ public class BndContainer implements IClasspathContainer {
         return lastModified.get();
     }
 
-    void updateLastModified(long time) {
+    boolean updateLastModified(long time) {
         for (long current = lastModified.get(); time > current; current = lastModified.get()) {
             if (lastModified.compareAndSet(current, time)) {
-                return;
+                return true;
             }
         }
+        return false;
     }
 }

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -38,7 +38,8 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.JavaModelManager;
-import org.osgi.util.function.Function;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.CircularDependencyException;
 import aQute.bnd.build.Container;
@@ -64,9 +65,9 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 
     public BndContainerInitializer() {
         super();
-        Central.onWorkspaceInit(new Function<Workspace,Void>() {
+        Central.onWorkspaceInit(new Success<Workspace,Void>() {
             @Override
-            public Void apply(Workspace t) {
+            public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
                 Central.getInstance().addModelListener(BndContainerInitializer.this);
                 return null;
             }

--- a/bndtools.builder/src/org/bndtools/builder/classpath/ClasspathContainerSerializationHelper.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/ClasspathContainerSerializationHelper.java
@@ -1,0 +1,211 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2010 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.bndtools.builder.classpath;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IAccessRule;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathContainer;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.JavaCore;
+
+class ClasspathContainerSerializationHelper<C extends IClasspathContainer> {
+    C readContainer(File file) throws IOException, ClassNotFoundException {
+        try (FileInputStream in = new FileInputStream(file)) {
+            return readContainer(in);
+        }
+    }
+
+    C readContainer(InputStream in) throws IOException, ClassNotFoundException {
+        ObjectInputStream is = new ObjectInputStream(new BufferedInputStream(in)) {
+            {
+                enableResolveObject(true);
+            }
+
+            @Override
+            protected Object resolveObject(Object o) throws IOException {
+                if (o instanceof ProjectEntryReplace) {
+                    return ((ProjectEntryReplace) o).getEntry();
+                } else if (o instanceof LibraryEntryReplace) {
+                    return ((LibraryEntryReplace) o).getEntry();
+                } else if (o instanceof ClasspathAttributeReplace) {
+                    return ((ClasspathAttributeReplace) o).getAttribute();
+                } else if (o instanceof AccessRuleReplace) {
+                    return ((AccessRuleReplace) o).getAccessRule();
+                } else if (o instanceof PathReplace) {
+                    return ((PathReplace) o).getPath();
+                }
+                return super.resolveObject(o);
+            }
+        };
+        @SuppressWarnings("unchecked")
+        C container = (C) is.readObject();
+        return container;
+    }
+
+    void writeContainer(C container, File file) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            writeContainer(container, out);
+        }
+    }
+
+    void writeContainer(C container, OutputStream out) throws IOException {
+        ObjectOutputStream os = new ObjectOutputStream(new BufferedOutputStream(out)) {
+            {
+                enableReplaceObject(true);
+            }
+
+            @Override
+            protected Object replaceObject(Object o) throws IOException {
+                if (o instanceof IClasspathEntry) {
+                    IClasspathEntry e = (IClasspathEntry) o;
+                    if (e.getEntryKind() == IClasspathEntry.CPE_PROJECT) {
+                        return new ProjectEntryReplace(e);
+                    } else if (e.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
+                        return new LibraryEntryReplace(e);
+                    }
+                } else if (o instanceof IClasspathAttribute) {
+                    return new ClasspathAttributeReplace((IClasspathAttribute) o);
+                } else if (o instanceof IAccessRule) {
+                    return new AccessRuleReplace((IAccessRule) o);
+                } else if (o instanceof IPath) {
+                    return new PathReplace((IPath) o);
+                }
+                return super.replaceObject(o);
+            }
+        };
+        os.writeObject(container);
+        os.flush();
+    }
+
+    /**
+     * A library IClasspathEntry replacement used for object serialization
+     */
+    static final class LibraryEntryReplace implements Serializable {
+        private static final long serialVersionUID = 3901667379326978799L;
+
+        private final IPath path;
+        private final IPath sourceAttachmentPath;
+        private final IPath sourceAttachmentRootPath;
+        private final IClasspathAttribute[] extraAttributes;
+        private final boolean exported;
+        private final IAccessRule[] accessRules;
+
+        LibraryEntryReplace(IClasspathEntry entry) {
+            this.path = entry.getPath();
+            this.sourceAttachmentPath = entry.getSourceAttachmentPath();
+            this.sourceAttachmentRootPath = entry.getSourceAttachmentRootPath();
+            this.accessRules = entry.getAccessRules();
+            this.extraAttributes = entry.getExtraAttributes();
+            this.exported = entry.isExported();
+        }
+
+        IClasspathEntry getEntry() {
+            return JavaCore.newLibraryEntry(path, sourceAttachmentPath, sourceAttachmentRootPath, //
+                    accessRules, extraAttributes, exported);
+        }
+    }
+
+    /**
+     * A project IClasspathEntry replacement used for object serialization
+     */
+    static final class ProjectEntryReplace implements Serializable {
+        private static final long serialVersionUID = -2397483865904288762L;
+
+        private final IPath path;
+        private final IClasspathAttribute[] extraAttributes;
+        private final IAccessRule[] accessRules;
+        private final boolean exported;
+        private final boolean combineAccessRules;
+
+        ProjectEntryReplace(IClasspathEntry entry) {
+            this.path = entry.getPath();
+            this.accessRules = entry.getAccessRules();
+            this.extraAttributes = entry.getExtraAttributes();
+            this.exported = entry.isExported();
+            this.combineAccessRules = entry.combineAccessRules();
+        }
+
+        IClasspathEntry getEntry() {
+            return JavaCore.newProjectEntry(path, accessRules, //
+                    combineAccessRules, extraAttributes, exported);
+        }
+    }
+
+    /**
+     * An IClasspathAttribute replacement used for object serialization
+     */
+    static final class ClasspathAttributeReplace implements Serializable {
+        private static final long serialVersionUID = 6370039352012628029L;
+
+        private final String name;
+        private final String value;
+
+        ClasspathAttributeReplace(IClasspathAttribute attribute) {
+            this.name = attribute.getName();
+            this.value = attribute.getValue();
+        }
+
+        IClasspathAttribute getAttribute() {
+            return JavaCore.newClasspathAttribute(name, value);
+        }
+    }
+
+    /**
+     * An IAccessRule replacement used for object serialization
+     */
+    static final class AccessRuleReplace implements Serializable {
+        private static final long serialVersionUID = 7315582893941374715L;
+
+        private final IPath pattern;
+        private final int kind;
+
+        AccessRuleReplace(IAccessRule accessRule) {
+            pattern = accessRule.getPattern();
+            kind = accessRule.getKind() | (accessRule.ignoreIfBetter() ? IAccessRule.IGNORE_IF_BETTER : 0);
+        }
+
+        IAccessRule getAccessRule() {
+            return JavaCore.newAccessRule(pattern, kind);
+        }
+    }
+
+    /**
+     * An IPath replacement used for object serialization
+     */
+    static final class PathReplace implements Serializable {
+        private static final long serialVersionUID = -2361259525684491181L;
+
+        private final String path;
+
+        PathReplace(IPath path) {
+            this.path = path.toPortableString();
+        }
+
+        IPath getPath() {
+            return Path.fromPortableString(path);
+        }
+    }
+}

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -40,7 +40,6 @@ import org.eclipse.jface.viewers.TreeViewer;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
-import org.osgi.util.function.Function;
 import org.osgi.util.promise.Deferred;
 import org.osgi.util.promise.Failure;
 import org.osgi.util.promise.Promise;
@@ -237,15 +236,9 @@ public class Central implements IStartupParticipant {
         return ws;
     }
 
-    public static void onWorkspaceInit(final Function<Workspace,Void> callback) {
+    public static void onWorkspaceInit(final Success<Workspace,Void> callback) {
         Promise<Workspace> p = workspaceQueue.getPromise();
-        p.then(new Success<Workspace,Void>() {
-            @Override
-            public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
-                callback.apply(resolved.getValue());
-                return null;
-            }
-        }).then(null, callbackFailure);
+        p.then(callback, null).then(null, callbackFailure);
     }
 
     private static final Failure callbackFailure = new Failure() {

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -241,6 +241,10 @@ public class Central implements IStartupParticipant {
         p.then(callback, null).then(null, callbackFailure);
     }
 
+    public static boolean isWorkspaceInited() {
+        return workspace != null;
+    }
+
     private static final Failure callbackFailure = new Failure() {
         @Override
         public void fail(Promise< ? > resolved) throws Exception {

--- a/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
+++ b/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
@@ -27,7 +27,8 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
-import org.osgi.util.function.Function;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Jar;
@@ -171,9 +172,9 @@ public class RepositoriesViewRefresher implements RepositoryListenerPlugin {
 
     public void addViewer(final TreeViewer viewer, final RefreshModel model) {
         this.viewers.put(viewer, model);
-        Central.onWorkspaceInit(new Function<Workspace,Void>() {
+        Central.onWorkspaceInit(new Success<Workspace,Void>() {
             @Override
-            public Void apply(Workspace a) {
+            public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
                 new Job("Updating repositories") {
                     @Override
                     protected IStatus run(IProgressMonitor monitor) {

--- a/bndtools.core/src/bndtools/central/WorkspaceListener.java
+++ b/bndtools.core/src/bndtools/central/WorkspaceListener.java
@@ -4,7 +4,8 @@ import java.io.File;
 
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
-import org.osgi.util.function.Function;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.Workspace;
 import aQute.bnd.service.BndListener;
@@ -20,9 +21,9 @@ public final class WorkspaceListener extends BndListener {
         try {
             final RefreshFileJob job = new RefreshFileJob(file, true);
             if (job.needsToSchedule()) {
-                Central.onWorkspaceInit(new Function<Workspace,Void>() {
+                Central.onWorkspaceInit(new Success<Workspace,Void>() {
                     @Override
-                    public Void apply(final Workspace ws) {
+                    public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
                         job.schedule();
                         return null;
                     }

--- a/bndtools.core/src/bndtools/central/WorkspaceR5Repository.java
+++ b/bndtools.core/src/bndtools/central/WorkspaceR5Repository.java
@@ -22,7 +22,8 @@ import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 import org.osgi.service.log.LogService;
-import org.osgi.util.function.Function;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
@@ -50,15 +51,10 @@ public class WorkspaceR5Repository extends BaseRepository {
     WorkspaceR5Repository() {}
 
     void init() throws Exception {
-        Central.onWorkspaceInit(new Function<Workspace,Void>() {
-
+        Central.onWorkspaceInit(new Success<Workspace,Void>() {
             @Override
-            public Void apply(Workspace a) {
-                try {
-                    setupProjects();
-                } catch (Exception e) {
-                    logger.logError("Error initializing workspace repository", e);
-                }
+            public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
+                setupProjects();
                 return null;
             }
         });

--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -69,7 +69,9 @@ import org.eclipse.ui.progress.UIJob;
 import org.eclipse.ui.texteditor.IDocumentProvider;
 import org.eclipse.ui.texteditor.IElementStateListener;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
-import org.osgi.util.function.Function;
+import org.osgi.util.promise.Deferred;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.Project;
 import aQute.bnd.build.Run;
@@ -458,20 +460,22 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
         setPartNameForInput(input);
         sourcePage.getDocumentProvider().addElementStateListener(new ElementStateListener());
 
-        Central.onWorkspaceInit(new Function<Workspace,Void>() {
+        Central.onWorkspaceInit(new Success<Workspace,Void>() {
             @Override
-            public Void apply(Workspace a) {
+            public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
+                final Deferred<Void> completion = new Deferred<>();
                 Display.getDefault().asyncExec(new Runnable() {
                     @Override
                     public void run() {
                         try {
                             loadEditModel();
+                            completion.resolve(null);
                         } catch (Exception e) {
-                            logger.logError("Error initializing workspace repository", e);
+                            completion.fail(e);
                         }
                     }
                 });
-                return null;
+                return completion.getPromise();
             }
         });
     }

--- a/bndtools.core/src/bndtools/editor/pages/ProjectRunPage.java
+++ b/bndtools.core/src/bndtools/editor/pages/ProjectRunPage.java
@@ -22,7 +22,9 @@ import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.osgi.util.function.Function;
+import org.osgi.util.promise.Deferred;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.Workspace;
 import aQute.bnd.build.model.BndEditModel;
@@ -90,16 +92,22 @@ public class ProjectRunPage extends FormPage {
         final ScrolledForm form = managedForm.getForm();
         form.setText("Resolve/Run");
 
-        Central.onWorkspaceInit(new Function<Workspace,Void>() {
+        Central.onWorkspaceInit(new Success<Workspace,Void>() {
             @Override
-            public Void apply(Workspace t) {
+            public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
+                final Deferred<Void> completion = new Deferred<>();
                 Display.getDefault().asyncExec(new Runnable() {
                     @Override
                     public void run() {
-                        updateFormImage(form);
+                        try {
+                            updateFormImage(form);
+                            completion.resolve(null);
+                        } catch (Exception e) {
+                            completion.fail(e);
+                        }
                     }
                 });
-                return null;
+                return completion.getPromise();
             }
         });
 

--- a/bndtools.core/src/bndtools/editor/workspace/WorkspaceMainPart.java
+++ b/bndtools.core/src/bndtools/editor/workspace/WorkspaceMainPart.java
@@ -32,7 +32,9 @@ import org.eclipse.ui.forms.widgets.ImageHyperlink;
 import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.osgi.util.function.Function;
+import org.osgi.util.promise.Deferred;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.Workspace;
 import bndtools.Plugin;
@@ -115,10 +117,10 @@ public class WorkspaceMainPart extends SectionPart {
         stackLayout.topControl = labelParent;
         container.layout();
 
-        Central.onWorkspaceInit(new Function<Workspace,Void>() {
-
+        Central.onWorkspaceInit(new Success<Workspace,Void>() {
             @Override
-            public Void apply(Workspace a) {
+            public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
+                final Deferred<Void> completion = new Deferred<>();
                 Display.getDefault().asyncExec(new Runnable() {
                     @Override
                     public void run() {
@@ -160,12 +162,14 @@ public class WorkspaceMainPart extends SectionPart {
 
                             stackLayout.topControl = contents;
                             container.layout();
+                            completion.resolve(null);
                         } catch (Exception e) {
                             Plugin.error(Collections.singletonList(e.getMessage()));
+                            completion.fail(e);
                         }
                     }
                 });
-                return null;
+                return completion.getPromise();
             }
         });
     }

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -92,7 +92,8 @@ import org.eclipse.ui.part.ResourceTransfer;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.resource.Requirement;
-import org.osgi.util.function.Function;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.Workspace;
 import aQute.bnd.service.Actionable;
@@ -400,9 +401,9 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
         fillToolBar(getViewSite().getActionBars().getToolBarManager());
 
         // call refresh action once to make sure someone is trying to load repositories in this view
-        Central.onWorkspaceInit(new Function<Workspace,Void>() {
+        Central.onWorkspaceInit(new Success<Workspace,Void>() {
             @Override
-            public Void apply(Workspace t) {
+            public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
                 refreshAction.run();
                 return null;
             }


### PR DESCRIPTION
 We use a classpath container serializer/deserializer helper from M2E to
serialize the BndContainer when it is set. During initialization of the
classpath container, if the workspace is initialized, we do the normal
container initialization. If the workspace is not initialized, we
deserialize the serialized BndContainer and use that. We also add a
callback to request an update once the workspace is initialized. If the
serialized container has the proper classpath, then no update is made.

Fixes #1449
