### PR TITLE
CellLabelProvider.getToolTipText() should return null instead of empty string.

### DIFF
--- a/bndtools.core/src/bndtools/model/resolution/CapabilityLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/CapabilityLabelProvider.java
@@ -41,8 +41,6 @@ public class CapabilityLabelProvider extends ImageCachingLabelProvider {
 
     @Override
     public String getToolTipText(Object element) {
-        String text;
-
         if (element instanceof Capability) {
             Capability cap = (Capability) element;
 
@@ -54,12 +52,10 @@ public class CapabilityLabelProvider extends ImageCachingLabelProvider {
             for (Entry<String,String> directive : cap.getDirectives().entrySet())
                 buf.append(";\n\t").append(directive.getKey()).append(" := ").append(directive.getValue());
 
-            text = buf.toString();
-        } else {
-            text = "";
+            return buf.toString();
         }
 
-        return text;
+        return null;
     }
 
 }

--- a/bndtools.core/src/bndtools/model/resolution/RequirementWrapperLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/RequirementWrapperLabelProvider.java
@@ -64,8 +64,6 @@ public class RequirementWrapperLabelProvider extends RequirementLabelProvider {
 
     @Override
     public String getToolTipText(Object element) {
-        String text;
-
         if (element instanceof RequirementWrapper) {
             RequirementWrapper rw = (RequirementWrapper) element;
             Requirement req = rw.requirement;
@@ -81,12 +79,10 @@ public class RequirementWrapperLabelProvider extends RequirementLabelProvider {
             for (Entry<String,String> directive : req.getDirectives().entrySet())
                 buf.append(";\n\t").append(directive.getKey()).append(" := ").append(directive.getValue());
 
-            text = buf.toString();
-        } else {
-            text = "";
+            return buf.toString();
         }
 
-        return text;
+        return null;
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Sean Bright <sean.bright@gmail.com>