### PR TITLE
Use HttpClient during repository DnD

### DIFF
--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -96,6 +96,7 @@ import org.osgi.util.promise.Promise;
 import org.osgi.util.promise.Success;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.http.HttpClient;
 import aQute.bnd.service.Actionable;
 import aQute.bnd.service.Refreshable;
 import aQute.bnd.service.RemoteRepositoryPlugin;
@@ -259,7 +260,9 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
                         }
 
                         File tmp = File.createTempFile("dwnl", ".jar");
-                        IO.copy(url, tmp);
+                        try (HttpClient client = new HttpClient()) {
+                            IO.copy(client.connect(url), tmp);
+                        }
 
                         if (isJarFile(tmp)) {
                             copied = addFilesToRepository((RepositoryPlugin) getCurrentTarget(), new File[] {


### PR DESCRIPTION
Java's built-in HttpUrlConnection will not follow redirects across
protocols (http -> https). bnd's HttpClient will, so use that instead
when dropping URLs on a repository.

Signed-off-by: Sean Bright <sean.bright@gmail.com>