### PR TITLE
Move static methods to silence private reference warning

### DIFF
--- a/bndtools.core/src/bndtools/central/RepositoryUtils.java
+++ b/bndtools.core/src/bndtools/central/RepositoryUtils.java
@@ -4,25 +4,18 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
+
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
-import org.bndtools.utils.repos.RepoUtils;
 
 import aQute.bnd.build.Workspace;
-import aQute.bnd.build.model.clauses.VersionedClause;
-import aQute.bnd.header.Attrs;
-import aQute.bnd.osgi.Constants;
 import aQute.bnd.service.RegistryPlugin;
 import aQute.bnd.service.RepositoryPlugin;
-import bndtools.model.repo.DependencyPhase;
-import bndtools.model.repo.RepositoryBundle;
-import bndtools.model.repo.RepositoryBundleVersion;
 
 public class RepositoryUtils {
     private static final ILogger logger = Logger.getLogger(RepositoryUtils.class);
 
     private static final String CACHE_REPO = "cache";
-    private static final String VERSION_LATEST = "latest";
 
     public static List<RepositoryPlugin> listRepositories(boolean hideCache) {
         Workspace workspace;
@@ -68,30 +61,4 @@ public class RepositoryUtils {
         }
         return Collections.emptyList();
     }
-
-    public static VersionedClause convertRepoBundle(RepositoryBundle bundle) {
-        Attrs attribs = new Attrs();
-        if (RepoUtils.isWorkspaceRepo(bundle.getRepo())) {
-            attribs.put(Constants.VERSION_ATTRIBUTE, VERSION_LATEST);
-        }
-        return new VersionedClause(bundle.getBsn(), attribs);
-    }
-
-    public static VersionedClause convertRepoBundleVersion(RepositoryBundleVersion bundleVersion, DependencyPhase phase) {
-        Attrs attribs = new Attrs();
-        if (RepoUtils.isWorkspaceRepo(bundleVersion.getParentBundle().getRepo()))
-            attribs.put(Constants.VERSION_ATTRIBUTE, VERSION_LATEST);
-        else {
-            StringBuilder builder = new StringBuilder();
-
-            builder.append(bundleVersion.getVersion().getMajor());
-            builder.append('.').append(bundleVersion.getVersion().getMinor());
-            if (phase != DependencyPhase.Build)
-                builder.append('.').append(bundleVersion.getVersion().getMicro());
-
-            attribs.put(Constants.VERSION_ATTRIBUTE, builder.toString());
-        }
-        return new VersionedClause(bundleVersion.getParentBundle().getBsn(), attribs);
-    }
-
 }

--- a/bndtools.core/src/bndtools/editor/project/RepositoryBundleSelectionPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RepositoryBundleSelectionPart.java
@@ -56,6 +56,7 @@ import org.eclipse.ui.forms.editor.IFormPage;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.part.ResourceTransfer;
+
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.header.Attrs;
@@ -63,12 +64,12 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
 import aQute.bnd.version.Version;
 import bndtools.Plugin;
-import bndtools.central.RepositoryUtils;
 import bndtools.editor.common.BndEditorPart;
 import bndtools.model.clauses.VersionedClauseLabelProvider;
 import bndtools.model.repo.DependencyPhase;
 import bndtools.model.repo.ProjectBundle;
 import bndtools.model.repo.RepositoryBundle;
+import bndtools.model.repo.RepositoryBundleUtils;
 import bndtools.model.repo.RepositoryBundleVersion;
 import bndtools.model.repo.RepositoryResourceElement;
 import bndtools.preferences.BndPreferences;
@@ -282,15 +283,15 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
                 while (iterator.hasNext()) {
                     Object item = iterator.next();
                     if (item instanceof RepositoryBundle) {
-                        VersionedClause newClause = RepositoryUtils.convertRepoBundle((RepositoryBundle) item);
+                        VersionedClause newClause = RepositoryBundleUtils.convertRepoBundle((RepositoryBundle) item);
                         adding.add(newClause);
                     } else if (item instanceof RepositoryBundleVersion) {
                         RepositoryBundleVersion bundleVersion = (RepositoryBundleVersion) item;
-                        VersionedClause newClause = RepositoryUtils.convertRepoBundleVersion(bundleVersion, phase);
+                        VersionedClause newClause = RepositoryBundleUtils.convertRepoBundleVersion(bundleVersion, phase);
                         adding.add(newClause);
                     } else if (item instanceof RepositoryResourceElement) {
                         RepositoryResourceElement elt = (RepositoryResourceElement) item;
-                        VersionedClause newClause = RepositoryUtils.convertRepoBundleVersion(elt.getRepositoryBundleVersion(), phase);
+                        VersionedClause newClause = RepositoryBundleUtils.convertRepoBundleVersion(elt.getRepositoryBundleVersion(), phase);
                         adding.add(newClause);
                     }
                 }

--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
@@ -1,0 +1,36 @@
+package bndtools.model.repo;
+
+import org.bndtools.utils.repos.RepoUtils;
+
+import aQute.bnd.build.model.clauses.VersionedClause;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.osgi.Constants;
+
+public class RepositoryBundleUtils {
+    private static final String VERSION_LATEST = "latest";
+
+    public static VersionedClause convertRepoBundle(RepositoryBundle bundle) {
+        Attrs attribs = new Attrs();
+        if (RepoUtils.isWorkspaceRepo(bundle.getRepo())) {
+            attribs.put(Constants.VERSION_ATTRIBUTE, VERSION_LATEST);
+        }
+        return new VersionedClause(bundle.getBsn(), attribs);
+    }
+
+    public static VersionedClause convertRepoBundleVersion(RepositoryBundleVersion bundleVersion, DependencyPhase phase) {
+        Attrs attribs = new Attrs();
+        if (RepoUtils.isWorkspaceRepo(bundleVersion.getParentBundle().getRepo()))
+            attribs.put(Constants.VERSION_ATTRIBUTE, VERSION_LATEST);
+        else {
+            StringBuilder builder = new StringBuilder();
+
+            builder.append(bundleVersion.getVersion().getMajor());
+            builder.append('.').append(bundleVersion.getVersion().getMinor());
+            if (phase != DependencyPhase.Build)
+                builder.append('.').append(bundleVersion.getVersion().getMicro());
+
+            attribs.put(Constants.VERSION_ATTRIBUTE, builder.toString());
+        }
+        return new VersionedClause(bundleVersion.getParentBundle().getBsn(), attribs);
+    }
+}

--- a/bndtools.core/src/bndtools/wizards/repo/RepoBundleSelectionWizardPage.java
+++ b/bndtools.core/src/bndtools/wizards/repo/RepoBundleSelectionWizardPage.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
 import org.eclipse.jface.viewers.IOpenListener;
@@ -49,6 +50,7 @@ import bndtools.model.clauses.VersionedClauseLabelProvider;
 import bndtools.model.repo.DependencyPhase;
 import bndtools.model.repo.ProjectBundle;
 import bndtools.model.repo.RepositoryBundle;
+import bndtools.model.repo.RepositoryBundleUtils;
 import bndtools.model.repo.RepositoryBundleVersion;
 import bndtools.model.repo.RepositoryTreeContentProvider;
 import bndtools.model.repo.RepositoryTreeLabelProvider;
@@ -293,9 +295,9 @@ public class RepoBundleSelectionWizardPage extends WizardPage {
         for (Iterator< ? > iter = selection.iterator(); iter.hasNext();) {
             Object item = iter.next();
             if (item instanceof RepositoryBundle) {
-                adding.add(RepositoryUtils.convertRepoBundle((RepositoryBundle) item));
+                adding.add(RepositoryBundleUtils.convertRepoBundle((RepositoryBundle) item));
             } else if (item instanceof RepositoryBundleVersion) {
-                adding.add(RepositoryUtils.convertRepoBundleVersion((RepositoryBundleVersion) item, phase));
+                adding.add(RepositoryBundleUtils.convertRepoBundleVersion((RepositoryBundleVersion) item, phase));
             } else if (item instanceof ProjectBundle) {
                 String bsn = ((ProjectBundle) item).getBsn();
                 Attrs attribs = new Attrs();


### PR DESCRIPTION
There is a lone problem marker in the Bndtools Eclipse workspace that reads:

`Export bndtools.central,  has 1,  private references [bndtools.model.repo]`

This is because RepositoryUtils exposed RepositoryBundle and
RepositoryBundleVersion as arguments to a couple static methods. This patch
moves those static methods to a new class in a non-exported package to
squelch the warning.

Signed-of-by: Sean Bright <sean.bright@gmail.com>