### PR TITLE
Remove trailing tildes from repository paths

### DIFF
--- a/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitHubWorkspaceTemplateLoader.java
+++ b/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitHubWorkspaceTemplateLoader.java
@@ -55,7 +55,7 @@ public class GitHubWorkspaceTemplateLoader implements TemplateLoader {
 
         Parameters githubRepos = new GitRepoPreferences().getGithubRepos();
         for (Entry<String,Attrs> entry : githubRepos.entrySet()) {
-            final String repo = entry.getKey();
+            final String repo = GitRepoPreferences.removeDuplicateMarker(entry.getKey());
             final Attrs attribs = entry.getValue();
 
             try {

--- a/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitRepoPreferences.java
+++ b/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitRepoPreferences.java
@@ -52,4 +52,8 @@ public class GitRepoPreferences {
         }
         return true;
     }
+
+    public static String removeDuplicateMarker(String s) {
+        return s.replaceAll("~+$", "");
+    }
 }

--- a/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/PlainGitWorkspaceTemplateLoader.java
+++ b/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/PlainGitWorkspaceTemplateLoader.java
@@ -42,7 +42,7 @@ public class PlainGitWorkspaceTemplateLoader implements TemplateLoader {
 
         Parameters gitRepos = new GitRepoPreferences().getGitRepos();
         for (Entry<String,Attrs> entry : gitRepos.entrySet()) {
-            String cloneUrl = entry.getKey();
+            String cloneUrl = GitRepoPreferences.removeDuplicateMarker(entry.getKey());
             Attrs attribs = entry.getValue();
 
             try {

--- a/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/ui/EditableParametersPart.java
+++ b/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/ui/EditableParametersPart.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 
+import org.bndtools.templating.jgit.GitRepoPreferences;
 import org.bndtools.utils.jface.BoldStyler;
 import org.bndtools.utils.swt.AddRemoveButtonBarPart;
 import org.bndtools.utils.swt.AddRemoveButtonBarPart.AddRemoveListener;
@@ -64,7 +65,7 @@ public class EditableParametersPart {
     public void setParameters(Parameters params) {
         entries = new ArrayList<>(params.size());
         for (Entry<String,Attrs> entry : params.entrySet()) {
-            entries.add(new Pair<>(entry.getKey(), entry.getValue()));
+            entries.add(new Pair<>(GitRepoPreferences.removeDuplicateMarker(entry.getKey()), entry.getValue()));
         }
     }
 


### PR DESCRIPTION
`aQute.bnd.header.Parameters` adds trailing tildes to disambiguate duplicated
keys, so we need to remove them when displaying them or attempting to access
them.

I'm not in love with this, and it prevents Git clone URIs from ending with
tildes (I'm not sure how much of a problem that is in practice).

Fixes #1471

Signed-off-by: Sean Bright <sean.bright@gmail.com>