### PR TITLE
deadlock fix: Remove unneeded synchronization

### DIFF
--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -183,7 +183,7 @@ public class Central implements IStartupParticipant {
         return getWorkspace().getWorkspaceRepository();
     }
 
-    public synchronized static Workspace getWorkspaceIfPresent() {
+    public static Workspace getWorkspaceIfPresent() {
         try {
             return getWorkspace();
         } catch (IllegalStateException e) {


### PR DESCRIPTION
getWorkspace will handle the necessary synchronization.
