### PR TITLE
Clean up use of Central.getProject

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -116,7 +116,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
 
             if (model == null) {
                 try {
-                    model = Central.getProject(myProject.getLocation().toFile());
+                    model = Central.getProject(myProject);
                 } catch (Exception e) {
                     markers.deleteMarkers("*");
 
@@ -325,7 +325,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
             IProject myProject = getProject();
             final Project model;
             try {
-                model = Central.getProject(myProject.getLocation().toFile());
+                model = Central.getProject(myProject);
             } catch (Exception e) {
                 MarkerSupport markers = new MarkerSupport(myProject);
                 markers.deleteMarkers("*");

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -238,7 +238,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 
             Project p = null;
             try {
-                p = Central.getProject(project.getLocation().toFile());
+                p = Central.getProject(project);
             } catch (Exception e) {
                 // this can happen during first project creation in an empty workspace
                 logger.logInfo("Unable to get bnd project for project " + project.getName(), e);

--- a/bndtools.builder/src/org/bndtools/builder/indexer/BuiltBundleIndexer.java
+++ b/bndtools.builder/src/org/bndtools/builder/indexer/BuiltBundleIndexer.java
@@ -69,7 +69,7 @@ public class BuiltBundleIndexer extends AbstractBuildListener {
         File indexFile;
         OutputStream output = null;
         try {
-            Project model = Central.getProject(project.getLocation().toFile());
+            Project model = Central.getProject(project);
             File target = model.getTarget();
             indexFile = new File(target, INDEX_FILENAME);
 
@@ -84,6 +84,7 @@ public class BuiltBundleIndexer extends AbstractBuildListener {
 
             // Use an analyzer to add a marker capability to workspace resources
             indexer.addAnalyzer(new ResourceAnalyzer() {
+                @Override
                 public void analyzeResource(Resource resource, List<Capability> capabilities, List<Requirement> requirements) throws Exception {
                     Capability cap = new Builder().setNamespace("bndtools.workspace").addAttribute("bndtools.workspace", workspaceRootUri.toString()).addAttribute("project.path", project.getFullPath().toString()).buildCapability();
                     capabilities.add(cap);

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -135,9 +135,8 @@ public class Central implements IStartupParticipant {
         try {
             Project model = javaProjectToModel.get(project);
             if (model == null) {
-                File projectDir = project.getProject().getLocation().makeAbsolute().toFile();
                 try {
-                    model = getProject(projectDir);
+                    model = getProject(project.getProject());
                 } catch (IllegalArgumentException e) {
                     // initialiseWorkspace();
                     // model = Central.getProject(projectDir);
@@ -544,11 +543,7 @@ public class Central implements IStartupParticipant {
     }
 
     public static Project getProject(File projectDir) throws Exception {
-        File projectDirAbsolute = projectDir.getAbsoluteFile();
-        assert projectDirAbsolute.isDirectory();
-
-        Workspace ws = getWorkspace();
-        return ws.getProject(projectDir.getName());
+        return getWorkspace().getProjectFromFile(projectDir);
     }
 
     public static Project getProject(IProject p) throws Exception {

--- a/bndtools.core/src/bndtools/central/WorkspaceR5Repository.java
+++ b/bndtools.core/src/bndtools/central/WorkspaceR5Repository.java
@@ -63,7 +63,7 @@ public class WorkspaceR5Repository extends BaseRepository {
     void setupProjects() throws Exception {
         IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
         for (IProject project : projects) {
-            Project model = Central.getProject(project.getLocation().toFile());
+            Project model = Central.getProject(project);
             if (model != null) {
                 File targetDir = getTarget(model);
                 if (targetDir != null) {

--- a/bndtools.core/src/bndtools/editor/exports/ExportPatternsListPart.java
+++ b/bndtools.core/src/bndtools/editor/exports/ExportPatternsListPart.java
@@ -256,8 +256,7 @@ public class ExportPatternsListPart extends PkgPatternsListPart<ExportedPackage>
             File bndFile = model.getBndResource();
             IPath path = Central.toPath(bndFile);
             IFile resource = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
-            File projectDir = resource.getProject().getLocation().toFile();
-            project = Central.getProject(projectDir);
+            project = Central.getProject(resource.getProject());
         } catch (Exception e) {
             logger.logError("Error getting project from editor model", e);
         }

--- a/bndtools.core/src/bndtools/editor/project/RunBundlesPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunBundlesPart.java
@@ -57,7 +57,7 @@ public class RunBundlesPart extends RepositoryBundleSelectionPart {
 
     private void loadBuilders(IProject project) {
         try {
-            Project model = Central.getProject(project.getLocation().toFile());
+            Project model = Central.getProject(project);
             if (model != null)
                 projectBuilders.addAll(model.getSubBuilders());
         } catch (Exception e) {


### PR DESCRIPTION
Use the proper overload and change implementation to use new
Workspace.getProjectFromFile method.