### PR TITLE
Change how we select the first element in template wizards

### DIFF
--- a/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.bndtools.templating.Category;
 import org.bndtools.templating.Template;
 import org.bndtools.templating.TemplateLoader;
 import org.bndtools.utils.jface.ProgressRunner;
@@ -377,8 +378,26 @@ public class TemplateSelectionWizardPage extends WizardPage {
         viewer.setInput(templates);
         viewer.expandAll();
 
-        Template first = contentProvider.getFirstTemplate();
-        viewer.setSelection(first != null ? new StructuredSelection(first) : StructuredSelection.EMPTY, true);
+        Template templateToSelect = null;
+
+        if (viewer.getFilters().length == 0) {
+            templateToSelect = contentProvider.getFirstTemplate();
+        } else {
+            for (Object element : contentProvider.getElements(null)) {
+                if (element instanceof Category) {
+                    Object[] filteredTemplates = latestFilter.filter(viewer, element, contentProvider.getChildren(element));
+                    if (filteredTemplates.length > 0) {
+                        templateToSelect = (Template) filteredTemplates[0];
+                        break;
+                    }
+                } else {
+                    templateToSelect = (Template) element;
+                    break;
+                }
+            }
+        }
+
+        viewer.setSelection(templateToSelect == null ? StructuredSelection.EMPTY : new StructuredSelection(templateToSelect));
     }
 
     public void setTemplate(final Template template) {

--- a/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
@@ -397,7 +397,11 @@ public class TemplateSelectionWizardPage extends WizardPage {
             }
         }
 
-        viewer.setSelection(templateToSelect == null ? StructuredSelection.EMPTY : new StructuredSelection(templateToSelect));
+        if (templateToSelect == null) {
+            return;
+        }
+
+        viewer.setSelection(new StructuredSelection(templateToSelect));
     }
 
     public void setTemplate(final Template template) {


### PR DESCRIPTION
The problem here is that the `RepoTemplateContentProvider.getFirstTemplate`
method returns (aptly) the first template, but that template might be
filtered out by the `ViewerFilter` associated with the `TreeViewer`.

So we jump through a few hoops to filter the `ContentProvider` contents so
that we select the first _visible_ template in the `TreeViewer`.

Signed-off-by: Sean Bright <sean.bright@gmail.com>