### PR TITLE
build: Package latest bnd jars

### DIFF
--- a/bndtools.repository.base/bnd.bnd
+++ b/bndtools.repository.base/bnd.bnd
@@ -20,7 +20,7 @@ bundlehub-template-resources: \
 	${bundlehub-template}/nonosgi-repo/=templates/repos/nonosgi-repo,\
 	${bundlehub-template}/localrepo/=templates/repos/localrepo,\
 	${bundlehub-template}/releaserepo/=templates/repos/releaserepo,\
-	${bundlehub-template}/plugins/biz.aQute.repository/biz.aQute.repository.jar=${repo;biz.aQute.repository;${bnd-version-base}}
+	${bundlehub-template}/plugins/biz.aQute.repository/biz.aQute.repository.jar=${repo;biz.aQute.repository;[${bnd-version-base},${bnd-version-ceiling})}
 
 jpm-template: templates/cnfs/jpm
 jpm-template-resources: \
@@ -28,7 +28,7 @@ jpm-template-resources: \
 	${jpm-template}=templates/unprocessed/jpm,\
 	${jpm-template}/localrepo/=templates/repos/localrepo,\
 	${jpm-template}/releaserepo/=templates/repos/releaserepo,\
-	${jpm-template}/plugins/biz.aQute.repository/biz.aQute.repository.jar=${repo;biz.aQute.repository;${bnd-version-base}}
+	${jpm-template}/plugins/biz.aQute.repository/biz.aQute.repository.jar=${repo;biz.aQute.repository;[${bnd-version-base},${bnd-version-ceiling})}
 
 -privatepackage: org.bndtools.wizards.workspace.legacy
 -includeresource:\

--- a/build/main.bnd
+++ b/build/main.bnd
@@ -1,10 +1,10 @@
 # Only extra bundles that are needed for the feature are mentioned here
 -resourceonly: true
 -includeresource: \
-    ${repo;biz.aQute.bndlib;${bnd-version-base}},\
-    ${repo;org.osgi.impl.bundle.repoindex.lib;${bnd-version-base}},\
-    ${repo;biz.aQute.repository;${bnd-version-base}},\
-    ${repo;biz.aQute.resolve;${bnd-version-base}},\
+    ${repo;biz.aQute.bndlib;[${bnd-version-base},${bnd-version-ceiling})},\
+    ${repo;org.osgi.impl.bundle.repoindex.lib;[${bnd-version-base},${bnd-version-ceiling})},\
+    ${repo;biz.aQute.repository;[${bnd-version-base},${bnd-version-ceiling})},\
+    ${repo;biz.aQute.resolve;[${bnd-version-base},${bnd-version-ceiling})},\
     ${repo;org.slf4j.api;latest},\
     ${repo;javax.xml;latest},\
     ${repo;javax.xml.stream;latest}

--- a/org.bndtools.headless.build.plugin.ant/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.ant/bnd.bnd
@@ -14,7 +14,7 @@
 
 -includeresource: \
 	templates=resources/templates/unprocessed,\
-	templates/cnf/plugins/biz.aQute.bnd/biz.aQute.bnd.jar=${repo;biz.aQute.bnd;${bnd-version-base}}
+	templates/cnf/plugins/biz.aQute.bnd/biz.aQute.bnd.jar=${repo;biz.aQute.bnd;[${bnd-version-base},${bnd-version-ceiling})}
 
 # we really need this, otherwise Eclipse will not start our bundles
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Use version range for packaging so that when building against a local
bnd build, you use the latest snapshot.
