### PR TITLE
Remove import of component.annotations

### DIFF
--- a/bndtools.release/bnd.bnd
+++ b/bndtools.release/bnd.bnd
@@ -8,7 +8,6 @@ Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 
 Import-Package: !junit*,org.eclipse.core.runtime;registry=!,\
-	org.osgi.service.component.annotations;resolution:=optional,\
 	*;ui.workbench=!;common=!;registry=!;texteditor=!;text=!
 
 Private-Package: \


### PR DESCRIPTION
They are not runtime annotations and there does not appear to be any code
in the bundle which even uses them.
