### PR TITLE
Add delay to refreshing workspace repositories

### DIFF
--- a/bndtools.core/src/bndtools/central/WorkspaceRepositoryChangeDetector.java
+++ b/bndtools.core/src/bndtools/central/WorkspaceRepositoryChangeDetector.java
@@ -14,13 +14,12 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.Job;
-
 import aQute.bnd.build.Workspace;
 import aQute.bnd.build.WorkspaceRepository;
 import aQute.bnd.service.RepositoryListenerPlugin;
@@ -122,9 +121,9 @@ public class WorkspaceRepositoryChangeDetector implements Closeable, IResourceCh
                 event.getDelta().accept(rootFolderVisitor);
 
                 if (refresh.getAndSet(false)) {
-                    Job job = new Job("Refresh Workspace Repository") {
+                    WorkspaceJob job = new WorkspaceJob("Refresh Workspace Repository") {
                         @Override
-                        protected IStatus run(IProgressMonitor monitor) {
+                        public IStatus runInWorkspace(IProgressMonitor monitor) {
                             if (monitor == null)
                                 monitor = new NullProgressMonitor();
                             List<RepositoryListenerPlugin> plugins = workspace.getPlugins(RepositoryListenerPlugin.class);
@@ -141,8 +140,7 @@ public class WorkspaceRepositoryChangeDetector implements Closeable, IResourceCh
                             return Status.OK_STATUS;
                         }
                     };
-                    job.setPriority(Job.SHORT);
-                    job.schedule();
+                    job.schedule(500);
                 }
             }
         } catch (CoreException e) {


### PR DESCRIPTION
This is to try and avoid a race condition with bnd refreshing projects.