### PR TITLE
build: Set DS default version to 1.0

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -67,6 +67,9 @@ Bundle-SCM:               url=https://github.com/bndtools/bndtools, \
                           connection=scm:git:https://github.com/bndtools/bndtools.git, \
                           developerConnection=scm:git:git@github.com:bndtools/bndtools.git
 
+# Bnd 3.4 defaults to 1.3 as the base DS version. We want to work with older
+# DS versions since Eclipse Equinox DS currently does not support DS 1.3.
+-dsannotations-options.version: version;minimum=1.0.0
 
 -diffignore: Git-Descriptor,Git-SHA
 


### PR DESCRIPTION
Bnd 3.4 defaults to 1.3 as the base DS version. We want to work with
older DS versions since Eclipse Equinox DS currently does not support
DS 1.3.