### PR TITLE
Remove unnecessary null check in LaunchUtils

### DIFF
--- a/bndtools.core/src/bndtools/launch/util/LaunchUtils.java
+++ b/bndtools.core/src/bndtools/launch/util/LaunchUtils.java
@@ -24,9 +24,6 @@ public final class LaunchUtils {
             return null;
 
         IResource targetResource = ResourcesPlugin.getWorkspace().getRoot().findMember(target);
-        if (targetResource == null)
-            return null;
-
         return targetResource;
     }
 


### PR DESCRIPTION
Closes #1600 Unnecessary null check in LaunchUtils::getTargetResource()
Signed-off-by: Rüdiger Herrmann <ruediger.herrmann@gmx.de>