### PR TITLE
ConcurrentModificationException during build #1632

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/MarkerSupport.java
+++ b/bndtools.builder/src/org/bndtools/builder/MarkerSupport.java
@@ -79,7 +79,7 @@ class MarkerSupport {
     }
 
     private void createMarkers(Processor model, int severity, Collection<String> msgs, String markerType) throws Exception {
-        for (String msg : msgs) {
+        for (String msg : msgs.toArray(new String[0])) {
             createMarker(model, severity, msg, markerType);
         }
     }


### PR DESCRIPTION
This fixes a potential issue with MarkerSupport in which a ConcurrentModificationException may occur, as per issue #1632. 

This fix affects MarkerSupport.createMarkers, creates a copy of the input parameter Collection<String> msgs, and iterates on the copy rather than the original to avoid the possibility of a ConcurrentModificationException.