### PR TITLE
916: seamless project import into eclipse

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -1020,5 +1020,20 @@
          commandId="bnd.launch.runShortcut.debug"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
    </extension>
+   <extension
+         point="org.eclipse.ui.importWizards">
+      <category
+		name="Bndtools"
+        id="bndtools.importCategory">
+      </category>
+		<wizard
+            id="bndtools.importProject"
+            category="bndtools.importCategory"
+            class="bndtools.wizards.project.ImportBndWorkspaceWizard"
+            icon="icons/bndtools-logo-16x16.png"
+            name="Existing Bnd Workspace"
+            project="true">
+      </wizard>
+   </extension>
 
  </plugin>

--- a/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizard.java
@@ -1,0 +1,473 @@
+package bndtools.wizards.project;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.filesystem.URIUtil;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
+import org.eclipse.jface.dialogs.ErrorDialog;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IImportWizard;
+import org.eclipse.ui.IPerspectiveDescriptor;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.WorkbenchException;
+import org.eclipse.ui.actions.WorkspaceModifyOperation;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import bndtools.BndConstants;
+import bndtools.Plugin;
+
+public class ImportBndWorkspaceWizard extends Wizard implements IImportWizard {
+
+    private IWorkbench workbench;
+
+    private ImportBndWorkspaceWizardPageOne mainPage;
+
+    @Override
+    public void init(IWorkbench workbench, IStructuredSelection selection) {
+        this.workbench = workbench;
+        setWindowTitle("Import Bnd Workspace");
+        setDefaultPageImageDescriptor(ImageDescriptor.createFromURL(Plugin.getDefault().getBundle().getEntry("icons/bndtools-wizban.png")));
+
+    }
+
+    @Override
+    public void addPages() {
+        super.addPages();
+        mainPage = new ImportBndWorkspaceWizardPageOne("Select");
+        addPage(mainPage);
+    }
+
+    @Override
+    public boolean performFinish() {
+
+        final ImportSettings importSettings = new ImportSettings(mainPage.getSelectedFolder(), mainPage.isDeleteSettings(), mainPage.isInferExecutionEnvironment());
+        // create the new project operation
+        final WorkspaceModifyOperation op = new WorkspaceModifyOperation() {
+            @Override
+            protected void execute(IProgressMonitor monitor) throws CoreException {
+                try {
+                    importProjects(importSettings, monitor);
+                } catch (Exception e) {
+                    throw new CoreException(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, "Error during import of Bnd workspace!", e));
+                }
+            }
+        };
+
+        Job importJob = new Job("Import Bnd Workspace") {
+            @Override
+            protected IStatus run(IProgressMonitor monitor) {
+                try {
+                    op.run(monitor);
+                } catch (InvocationTargetException e) {
+                    Throwable t = e.getCause();
+                    if (t instanceof CoreException && ((CoreException) t).getStatus().getException() != null) {
+                        // unwrap the cause of the CoreException
+                        t = ((CoreException) t).getStatus().getException();
+                    }
+                    return new Status(Status.ERROR, Plugin.PLUGIN_ID, "Could not finish import job for Bnd Workspace!", t);
+                } catch (InterruptedException e) {
+                    return Status.CANCEL_STATUS;
+                }
+                return Status.OK_STATUS;
+            }
+        };
+
+        importJob.schedule();
+
+        try {
+            // Prompt to switch to the BndTools perspective
+            IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+            IPerspectiveDescriptor currentPerspective = window.getActivePage().getPerspective();
+            if (!"bndtools.perspective".equals(currentPerspective.getId())) {
+                if (MessageDialog.openQuestion(getShell(), "Bndtools Perspective", "Switch to the Bndtools perspective?")) {
+                    this.workbench.showPerspective("bndtools.perspective", window);
+                }
+            }
+        } catch (WorkbenchException e) {
+            error("Unable to switch to BndTools perspective", e);
+        }
+        return true;
+    }
+
+    private void deleteOldProjectFiles(final Path projectPath) throws IOException {
+        final Path settings = projectPath.resolve(".settings");
+        if (Files.exists(settings)) {
+            Files.walkFileTree(settings, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+
+        final Path project = projectPath.resolve(".project");
+        Files.deleteIfExists(project);
+        final Path classpath = projectPath.resolve(".classpath");
+        Files.deleteIfExists(classpath);
+    }
+
+    private boolean importProjects(final ImportSettings importSettings, IProgressMonitor monitor) throws Exception {
+        Workspace bndWorkspace = Workspace.getWorkspace(importSettings.rootImportPath);
+
+        int steps = bndWorkspace.getAllProjects().size() + 2;
+
+        monitor.beginTask("Importing Bnd workspace", steps);
+
+        importConfigurationProject(importSettings, monitor);
+
+        // Import Projects
+        for (Project bndProject : bndWorkspace.getAllProjects()) {
+            importBndProject(bndProject, bndWorkspace, importSettings, monitor);
+        }
+
+        // build
+        monitor.subTask("Building workspace");
+        ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, monitor);
+        monitor.worked(1);
+        monitor.done();
+
+        return true;
+    }
+
+    private void importConfigurationProject(final ImportSettings importSettings, IProgressMonitor monitor) throws Exception {
+        monitor.subTask("Import configuration project 'cnf'.");
+        final IWorkspace eclipseWorkspace = ResourcesPlugin.getWorkspace();
+        final IWorkspaceRoot eclipseWorkspaceRoot = eclipseWorkspace.getRoot();
+        final Workspace bndWorkspace = Workspace.getWorkspace(importSettings.rootImportPath);
+
+        // Prepare Eclipse Workspace
+        updateEclipseWorkspaceSettings(bndWorkspace);
+
+        // create generic project
+        final IProjectDescription cnfProjectDescription = eclipseWorkspace.newProjectDescription(Workspace.CNFDIR);
+        final IProject project = eclipseWorkspaceRoot.getProject(Workspace.CNFDIR);
+
+        if (importSettings.deleteSettings) {
+            deleteOldProjectFiles(Paths.get(bndWorkspace.getBase().toURI()).resolve(Workspace.CNFDIR));
+        }
+
+        // create JavaProject
+        IPath path = URIUtil.toPath(bndWorkspace.getBuildDir().toURI());
+        if (Platform.getLocation().isPrefixOf(path)) {
+            cnfProjectDescription.setLocation(null);
+        } else {
+            cnfProjectDescription.setLocation(path);
+        }
+
+        if (!project.exists()) {
+            project.create(cnfProjectDescription, monitor);
+        }
+        if (!project.isOpen()) {
+            project.open(monitor);
+        }
+
+        monitor.worked(1);
+    }
+
+    private void importBndProject(final Project bndProject, final Workspace bndWorkspace, final ImportSettings importSettings, IProgressMonitor monitor) throws IOException, CoreException, Exception {
+        monitor.subTask("Import Bnd project '" + bndProject.getName() + "'.");
+        final IWorkspace eclipseWorkspace = ResourcesPlugin.getWorkspace();
+        final IWorkspaceRoot eclipseWorkspaceRoot = eclipseWorkspace.getRoot();
+
+        if (importSettings.deleteSettings) {
+            deleteOldProjectFiles(Paths.get(bndWorkspace.getBaseURI()).resolve(bndProject.getName()));
+        }
+        // create generic project
+        final IProjectDescription projectDescription = eclipseWorkspace.newProjectDescription(bndProject.getName());
+        final IProject project = eclipseWorkspaceRoot.getProject(bndProject.getName());
+
+        IPath path = URIUtil.toPath(bndProject.getBaseURI());
+        if (Platform.getLocation().isPrefixOf(path)) {
+            projectDescription.setLocation(null);
+        } else {
+            projectDescription.setLocation(path);
+        }
+
+        if (!project.exists()) {
+            project.create(projectDescription, monitor);
+        }
+        project.open(monitor);
+
+        setNatures(project, monitor, JavaCore.NATURE_ID, Plugin.BNDTOOLS_NATURE);
+
+        IJavaProject javaProject = JavaCore.create(project);
+        if (!javaProject.isOpen()) {
+            javaProject.open(monitor);
+        }
+        updateJavaProjectSettings(bndProject, javaProject, importSettings, monitor);
+
+        importSourceAndOutputFolders(bndProject, project, javaProject, monitor);
+    }
+
+    private void importSourceAndOutputFolders(Project bndProject, IProject workspaceProject, IJavaProject javaProject, IProgressMonitor monitor) throws Exception {
+        // remove defaults
+        removeClasspathDefaults(javaProject);
+
+        // Output
+        IFolder sourceOutput = workspaceProject.getFolder(URIUtil.toPath(bndProject.getSrcOutput().toURI()).makeRelativeTo(workspaceProject.getLocation()));
+        IPackageFragmentRoot outputRoot = javaProject.getPackageFragmentRoot(sourceOutput);
+
+        // Source (multiple possible)
+        for (File folder : bndProject.getSourcePath()) {
+            IFolder source = workspaceProject.getFolder(URIUtil.toPath(folder.toURI()).makeRelativeTo(workspaceProject.getLocation()));
+            // Now the created source folder should be added to the class entries of the project, otherwise compilation will fail
+            IPackageFragmentRoot root = javaProject.getPackageFragmentRoot(source);
+            List<IClasspathEntry> entries = new ArrayList<>(Arrays.asList(javaProject.getRawClasspath()));
+            entries.add(JavaCore.newSourceEntry(root.getPath(), null, outputRoot.getPath()));
+            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), monitor);
+            createFolderIfNecessary(source, monitor);
+        }
+        // Test-Source
+        javaProject.setOutputLocation(sourceOutput.getFullPath(), null);
+        if (!bndProject.getSrcOutput().equals(bndProject.getTestOutput())) {
+            IFolder testOutput = workspaceProject.getFolder(URIUtil.toPath(bndProject.getTestOutput().toURI()).makeRelativeTo(workspaceProject.getLocation()));
+            IPackageFragmentRoot testOutputRoot = javaProject.getPackageFragmentRoot(testOutput);
+            IFolder testSource = workspaceProject.getFolder(URIUtil.toPath(bndProject.getTestSrc().toURI()).makeRelativeTo(workspaceProject.getLocation()));
+            // Now the created source folder should be added to the class entries of the project, otherwise compilation will fail
+            IPackageFragmentRoot root = javaProject.getPackageFragmentRoot(testSource);
+            List<IClasspathEntry> entries = new ArrayList<>(Arrays.asList(javaProject.getRawClasspath()));
+            entries.add(JavaCore.newSourceEntry(root.getPath(), null, testOutputRoot.getPath()));
+            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), monitor);
+            createFolderIfNecessary(testSource, monitor);
+        }
+
+        // Generated Artifact
+        IFolder generated = workspaceProject.getFolder(URIUtil.toPath(bndProject.getTarget().toURI()).makeRelativeTo(workspaceProject.getLocation()));
+        createFolderIfNecessary(generated, monitor);
+    }
+
+    private void createFolderIfNecessary(IFolder folder, IProgressMonitor monitor) throws CoreException {
+        if (!folder.exists()) {
+            folder.create(true, true, monitor);
+        }
+    }
+
+    /**
+     * The Java-Nature doesn't add a JRE-Container, so we add one
+     *
+     * @param javaProject
+     *            the Java project which should get enhanced with LibraryContainer
+     * @param javacTarget
+     * @param monitor
+     *            current IProgressMonitor
+     * @throws JavaModelException
+     */
+    private void addSystemLibraryContainer(final IJavaProject javaProject, final String javacTarget, final ImportSettings importSettings, IProgressMonitor monitor) throws JavaModelException {
+        List<IClasspathEntry> entries = new ArrayList<>(Arrays.asList(javaProject.getRawClasspath()));
+        // entries.addAll(newContainerEntries);
+        // only add JRE-Container if none available
+        boolean jreContainerAvailable = false;
+        Iterator<IClasspathEntry> it = entries.iterator();
+        while (it.hasNext()) {
+            IClasspathEntry entry = it.next();
+            if (entry.getEntryKind() == IClasspathEntry.CPE_CONTAINER && entry.getPath() != null && entry.getPath().toString().startsWith(JavaRuntime.JRE_CONTAINER)) {
+                // remove existing entry if user want to infer EE
+                if (importSettings.inferExecutionEnvironment) {
+                    it.remove();
+                } else {
+                    jreContainerAvailable = true;
+                }
+                break;
+            }
+        }
+        if (!jreContainerAvailable) {
+            IClasspathEntry defaultJREContainerEntry = JavaRuntime.getDefaultJREContainerEntry();
+            if (importSettings.inferExecutionEnvironment) {
+                // fuzzy at the moment but better than nothing. We should find a way to handle CDC
+                IExecutionEnvironment environment = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("J2SE-" + javacTarget);
+                if (environment == null) {
+                    environment = JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-" + javacTarget);
+                }
+                if (environment != null) {
+                    entries.add(JavaCore.newContainerEntry(JavaRuntime.newJREContainerPath(environment)));
+                } else {
+                    Plugin.getDefault().getLog()
+                            .log(new Status(IStatus.WARNING, Plugin.PLUGIN_ID, 0, String.format("Could not infer execution-environment in project '%s' for javac.target '%s'", javaProject.getElementName(), javacTarget), null));
+                    entries.add(defaultJREContainerEntry);
+                }
+            } else {
+                entries.add(defaultJREContainerEntry);
+            }
+            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), monitor);
+        }
+    }
+
+    /**
+     * Update Eclipse workspace with information from a Bnd workspace Currently only compiler-settings are matched
+     *
+     * @param bndWorkspace
+     *            the imported Bnd workspace
+     */
+    private void updateEclipseWorkspaceSettings(final Workspace bndWorkspace) {
+        final String javacSource = bndWorkspace.getProperties().getProperty(BndConstants.JAVAC_SOURCE);
+        final String javacTarget = bndWorkspace.getProperties().getProperty(BndConstants.JAVAC_TARGET);
+
+        @SuppressWarnings("unchecked")
+        Hashtable<String,String> javaCoreOptions = JavaCore.getOptions();
+        if (javacSource != null) {
+            javaCoreOptions.put(JavaCore.COMPILER_SOURCE, javacSource);
+        }
+        if (javacTarget != null) {
+            javaCoreOptions.put(JavaCore.COMPILER_COMPLIANCE, javacTarget);
+            javaCoreOptions.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, javacTarget);
+        }
+        JavaCore.setOptions(javaCoreOptions);
+    }
+
+    /**
+     * Updates the JavaProject with project-level settings from a Bnd project. Currently only compiler-settings are
+     * matched if they differ from the Eclipse workspace (which has been set prior), as well as the JRE-SystemLibrary.
+     *
+     * @param bndProject
+     *            the imported BndProject
+     * @param javaProject
+     *            the newly created JavaProject
+     * @throws JavaModelException
+     */
+    private void updateJavaProjectSettings(final Project bndProject, final IJavaProject javaProject, final ImportSettings importSettings, IProgressMonitor monitor) throws JavaModelException {
+        final String javacSource = bndProject.getProperties().getProperty(BndConstants.JAVAC_SOURCE);
+        final String javacTarget = bndProject.getProperties().getProperty(BndConstants.JAVAC_TARGET);
+
+        addSystemLibraryContainer(javaProject, javacTarget, importSettings, monitor);
+
+        @SuppressWarnings("unchecked")
+        Map<String,String> projectOptions = javaProject.getOptions(false);
+        // only update project-specific settings when different from workspace
+        if (javacSource != null && !javacSource.equals(JavaCore.getOption(JavaCore.COMPILER_SOURCE))) {
+            projectOptions.put(JavaCore.COMPILER_SOURCE, javacSource);
+        }
+        if (javacTarget != null && !javacTarget.equals(JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE))) {
+            projectOptions.put(JavaCore.COMPILER_COMPLIANCE, javacTarget);
+        }
+        if (javacTarget != null && !javacTarget.equals(JavaCore.getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM))) {
+            projectOptions.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, javacTarget);
+        }
+        javaProject.setOptions(projectOptions);
+    }
+
+    /**
+     * Creating a JavaProject has the effect that there is an default source-folder in the RawClasspath which uses the
+     * project-directory itself. Furthermore, the BndProjectNature causes the classpath container to be available if the
+     * Repositories-View is still populated from a prior Workspace-Setup.
+     *
+     * @param javaProject
+     *            the Project which needs special treatment
+     * @throws JavaModelException
+     */
+    private void removeClasspathDefaults(IJavaProject javaProject) throws JavaModelException {
+        for (IPackageFragmentRoot root : javaProject.getPackageFragmentRoots()) {
+            if (!root.isArchive()) {
+                int jCoreFlags = IPackageFragmentRoot.NO_RESOURCE_MODIFICATION | IPackageFragmentRoot.ORIGINATING_PROJECT_CLASSPATH;
+                root.delete(IResource.NONE, jCoreFlags, null);
+            }
+        }
+    }
+
+    private void setNatures(IProject project, IProgressMonitor monitor, String... natureIds) throws CoreException {
+        IProjectDescription updatingDescription = project.getDescription();
+        updatingDescription.setNatureIds(natureIds);
+        project.setDescription(updatingDescription, monitor);
+    }
+
+    private void error(final String message, final Throwable t) {
+        // Log error
+        Plugin.getDefault().getLog().log(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, message, t));
+        // build the error message and include the current stack trace
+        final MultiStatus status = createMultiStatus(t);
+        Runnable run = new Runnable() {
+            @Override
+            public void run() {
+                // show error dialog
+                ErrorDialog.openError(null, "Error", message, status);
+            }
+        };
+        if (Display.getCurrent() == null) {
+            Display.getDefault().asyncExec(run);
+        } else {
+            run.run();
+        }
+    }
+
+    /*
+     * TODO probably something to move to Plugin
+     *
+     * creates a MultiStatus including StackTrace
+     */
+    private static MultiStatus createMultiStatus(Throwable t) {
+        List<Status> childStatuses = new ArrayList<>();
+        StackTraceElement[] stackTraces = Thread.currentThread().getStackTrace();
+
+        for (StackTraceElement stackTrace : stackTraces) {
+            Status status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID, stackTrace.toString());
+            childStatuses.add(status);
+        }
+
+        MultiStatus ms = new MultiStatus(Plugin.PLUGIN_ID, IStatus.ERROR, childStatuses.toArray(new Status[] {}), t.toString(), t);
+        return ms;
+    }
+
+    /**
+     * Wrapper class to hand user-settings for the import down the call-stack
+     */
+    private static final class ImportSettings {
+        final File rootImportPath;
+        final boolean deleteSettings;
+        final boolean inferExecutionEnvironment;
+
+        private ImportSettings(File rootImportPath, boolean deleteSettings, boolean inferExecutionEnvironment) {
+            this.rootImportPath = rootImportPath;
+            this.deleteSettings = deleteSettings;
+            this.inferExecutionEnvironment = inferExecutionEnvironment;
+        }
+    }
+
+}

--- a/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizardPageOne.java
+++ b/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizardPageOne.java
@@ -1,0 +1,379 @@
+package bndtools.wizards.project;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.fieldassist.ControlDecoration;
+import org.eclipse.jface.fieldassist.FieldDecoration;
+import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormData;
+import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.DirectoryDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE.SharedImages;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.osgi.Constants;
+import bndtools.Plugin;
+
+public class ImportBndWorkspaceWizardPageOne extends WizardPage {
+
+    private Text txtFolder;
+    private Button deleteButton;
+    private Button inferExecutionEnvironmentButton;
+    /**
+     * TableViewer is used to display an image for the project which is not possible with a ListViewer
+     */
+    private TableViewer tableViewer;
+    private ControlDecoration txtFolderErrorDecorator;
+
+    protected ImportBndWorkspaceWizardPageOne(String pageName) {
+        super(pageName);
+        setTitle("Bnd Workspace Projects");
+        setDescription("Select a root directory of Bnd Workspace");
+    }
+
+    /**
+     * Return the valid Bnd Workspace root, which was specified by the user Uses UI-Thread, do not call from other
+     * Threads
+     *
+     * @return valid folder
+     */
+    File getSelectedFolder() {
+        if (!isPageComplete()) {
+            throw new IllegalStateException("getSelectedFolder cannot be called before wizard-page is marked as complete!");
+        }
+        return new File(txtFolder.getText());
+    }
+
+    /**
+     * Return the selection, if the user wants to delete all existing settings. Uses UI-Thread, do not call from other
+     * Threads
+     *
+     * @return selection-state from checkbox
+     */
+    boolean isDeleteSettings() {
+        return deleteButton.getSelection();
+    }
+
+    /**
+     * Return the selection, if the user wants to infer the execution-environment from BND
+     * {@link Constants#JAVAC_TARGET}. Uses UI-Thread, do not call from other Threads
+     *
+     * @return selection-state from checkbox
+     */
+    boolean isInferExecutionEnvironment() {
+        return inferExecutionEnvironmentButton.getSelection();
+    }
+
+    @Override
+    public void createControl(final Composite parent) {
+        final Composite container = new Composite(parent, SWT.NONE);
+
+        Label lblFolder = new Label(container, SWT.NONE);
+        lblFolder.setText("Root Directory:");
+
+        txtFolder = new Text(container, SWT.BORDER | SWT.SINGLE);
+        txtFolder.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent event) {
+                getWizard().getContainer().updateButtons();
+            }
+        });
+
+        //Adding the decorator
+        txtFolderErrorDecorator = new ControlDecoration(txtFolder, SWT.TOP | SWT.RIGHT);
+        FieldDecoration fieldDecoration = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_ERROR);
+        Image img = fieldDecoration.getImage();
+        txtFolderErrorDecorator.setImage(img);
+        txtFolderErrorDecorator.setDescriptionText("Selected folder must contain valid Bnd Workspace configuration project.");
+        // hiding it initially
+        txtFolderErrorDecorator.hide();
+
+        Button btnOpenDialog = new Button(container, SWT.PUSH);
+        btnOpenDialog.setText("Browse...");
+        btnOpenDialog.addSelectionListener(new SelectionAdapter() {
+
+            @Override
+            public void widgetSelected(SelectionEvent event) {
+                DirectoryDialog dirDialog = new DirectoryDialog(container.getShell());
+                dirDialog.setFilterPath(ResourcesPlugin.getWorkspace().getRoot().getLocation().toOSString());
+                dirDialog.setText("Select the folder containing the project.");
+                txtFolder.setText(dirDialog.open());
+                getWizard().getContainer().updateButtons();
+            }
+        });
+
+        Label lblProjects = new Label(container, SWT.NONE);
+        lblProjects.setText("Projects:");
+
+        tableViewer = new TableViewer(container, SWT.V_SCROLL | SWT.H_SCROLL | SWT.BORDER);
+        tableViewer.setContentProvider(ArrayContentProvider.getInstance());
+        tableViewer.setComparator(new ViewerComparator() {
+            @Override
+            public int compare(Viewer viewer, Object e1, Object e2) {
+                // configuration project always first
+                if (e1 instanceof File && e2 instanceof Project) {
+                    return -1;
+                } else if (e1 instanceof Project && e2 instanceof File) {
+                    return 1;
+                }
+                Project p1 = (Project) e1;
+                Project p2 = (Project) e2;
+                return super.compare(viewer, p1.getName(), p2.getName());
+            }
+        });
+        tableViewer.addSelectionChangedListener(new ISelectionChangedListener() {
+            @Override
+            public void selectionChanged(final SelectionChangedEvent event) {
+                // Disable selection since the tableviewer should be readonly, but not disabled
+                if (!event.getSelection().isEmpty()) {
+                    tableViewer.setSelection(StructuredSelection.EMPTY);
+                }
+            }
+        });
+        TableViewerColumn column = new TableViewerColumn(tableViewer, SWT.NONE);
+        column.setLabelProvider(new ProjectsColumnLabelProvider());
+
+        Button refreshButton = new Button(container, SWT.PUSH);
+        refreshButton.setText("Refresh");
+        refreshButton.addSelectionListener(new SelectionAdapter() {
+
+            @Override
+            public void widgetSelected(SelectionEvent event) {
+                getWizard().getContainer().updateButtons();
+            }
+        });
+
+        deleteButton = new Button(container, SWT.CHECK);
+        deleteButton.setText("Delete existing settings");
+
+        inferExecutionEnvironmentButton = new Button(container, SWT.CHECK);
+        inferExecutionEnvironmentButton.setSelection(true);
+        inferExecutionEnvironmentButton.setText("Infer execution-environment (J2SE and JavaSE).");
+        inferExecutionEnvironmentButton
+                .setToolTipText("Uses the 'javac.target' from the Bnd Workspace to infer a Execution Environment to the JRE container. If nothing matches, the default JRE will be used.\nExisting containers will be removed.");
+
+        FormLayout layout = new FormLayout();
+        container.setLayout(layout);
+
+        FormData fd_lblFolder = new FormData();
+        fd_lblFolder.top = new FormAttachment(0, 10);
+        fd_lblFolder.left = new FormAttachment(0, 10);
+        lblFolder.setLayoutData(fd_lblFolder);
+
+        FormData fd_txtFolder = new FormData();
+        fd_txtFolder.top = new FormAttachment(lblFolder, 0, SWT.CENTER);
+        fd_txtFolder.left = new FormAttachment(lblFolder, 10);
+        fd_txtFolder.right = new FormAttachment(100, -100);
+        txtFolder.setLayoutData(fd_txtFolder);
+
+        FormData fd_btnDialog = new FormData();
+        fd_btnDialog.top = new FormAttachment(lblFolder, 0, SWT.CENTER);
+        fd_btnDialog.left = new FormAttachment(txtFolder, 10);
+        fd_btnDialog.right = new FormAttachment(100, -10);
+        btnOpenDialog.setLayoutData(fd_btnDialog);
+
+        FormData fd_lblProjects = new FormData();
+        fd_lblProjects.top = new FormAttachment(lblFolder, 20);
+        fd_lblProjects.left = new FormAttachment(lblFolder, 0, SWT.LEFT);
+        lblProjects.setLayoutData(fd_lblProjects);
+
+        FormData fd_table = new FormData();
+        fd_table.top = new FormAttachment(lblProjects, 5);
+        fd_table.left = new FormAttachment(lblFolder, 0, SWT.LEFT);
+        fd_table.right = new FormAttachment(100, -100);
+        fd_table.bottom = new FormAttachment(100, -55);
+        tableViewer.getTable().setLayoutData(fd_table);
+
+        FormData fd_btnRefresh = new FormData();
+        fd_btnRefresh.top = new FormAttachment(tableViewer.getTable(), 0, SWT.TOP);
+        fd_btnRefresh.left = new FormAttachment(btnOpenDialog, 0, SWT.LEFT);
+        fd_btnRefresh.right = new FormAttachment(100, -10);
+        refreshButton.setLayoutData(fd_btnRefresh);
+
+        FormData fd_btnDelete = new FormData();
+        fd_btnDelete.top = new FormAttachment(tableViewer.getTable(), 10);
+        fd_btnDelete.left = new FormAttachment(lblFolder, 0, SWT.LEFT);
+        deleteButton.setLayoutData(fd_btnDelete);
+
+        FormData fd_btnInfer = new FormData();
+        fd_btnInfer.top = new FormAttachment(deleteButton, 10);
+        fd_btnInfer.left = new FormAttachment(lblFolder, 0, SWT.LEFT);
+        inferExecutionEnvironmentButton.setLayoutData(fd_btnInfer);
+
+        getShell().setMinimumSize(470, 450);
+
+        // required to avoid an error in the system
+        setControl(parent);
+        setPageComplete(false);
+
+        txtFolder.setText(ResourcesPlugin.getWorkspace().getRoot().getLocation().toOSString());
+    }
+
+    @Override
+    public boolean canFlipToNextPage() {
+        // single page
+        return false;
+    }
+
+    @Override
+    public boolean isPageComplete() {
+        return updateWorkspaceSelection();
+    }
+
+    /**
+     * Takes the selected/typed folder from the the {@link #txtFolder} and tries to obtain a valid Bnd Workspace. In any
+     * case, the {@link #tableViewer} is updated.
+     *
+     * @return true, when a Bnd Workspace was selected and properly initialized
+     */
+    private boolean updateWorkspaceSelection() {
+        final String selectedFolder = txtFolder.getText();
+        boolean result = false;
+        // check if folder containing a cnf-folder for Bnd was selected
+        if (null != selectedFolder && selectedFolder.trim().length() > 0) {
+            File chosenDirectory = new File(txtFolder.getText());
+            if (chosenDirectory.exists()) {
+                final Workspace bndWorkspace;
+                try {
+                    bndWorkspace = Workspace.getWorkspace(chosenDirectory);
+                    setErrorMessage(null);
+                    txtFolderErrorDecorator.hide();
+                    List<Object> tableEntries = new ArrayList<Object>(bndWorkspace.getAllProjects());
+                    tableEntries.add(bndWorkspace.getBuildDir());
+                    tableViewer.setInput(tableEntries);
+                    result = true;
+                } catch (Exception e) {
+                    // not a valid Bnd Workspace folder
+                    setErrorMessage(e.getMessage());
+                    txtFolderErrorDecorator.show();
+                }
+            } else {
+                // handle non-existing folders
+                setErrorMessage("No Workspace found from: " + selectedFolder);
+                txtFolderErrorDecorator.show();
+            }
+        }
+        if (!result) {
+            tableViewer.setInput(Collections.emptyList());
+        }
+        for (TableColumn col : tableViewer.getTable().getColumns()) {
+            // make sure TableViewerColumn has enough width to display new selection
+            col.pack();
+        }
+        tableViewer.refresh();
+        return result;
+    }
+
+    private static final class ProjectsColumnLabelProvider extends ColumnLabelProvider {
+        private static final String KEY_GENERAL_PROJECT = ProjectsColumnLabelProvider.class.getName();
+        private static final String KEY_GENERAL_PROJECT_GREYSCALE = KEY_GENERAL_PROJECT + "_grey";
+        private static final String KEY_JAVA_PROJECT = KEY_GENERAL_PROJECT + "_java";
+        private static final String KEY_JAVA_PROJECT_GREYSCALE = KEY_JAVA_PROJECT + "_grey";
+
+        private ProjectsColumnLabelProvider() {
+            // prepare images (greyscale used for disabled)
+            if (Plugin.getDefault().getImageRegistry().get(KEY_GENERAL_PROJECT) == null) {
+                Image image = PlatformUI.getWorkbench().getSharedImages().getImage(SharedImages.IMG_OBJ_PROJECT);
+                Plugin.getDefault().getImageRegistry().put(KEY_GENERAL_PROJECT, image);
+                Plugin.getDefault().getImageRegistry().put(KEY_GENERAL_PROJECT_GREYSCALE, new Image(Display.getCurrent(), image, SWT.IMAGE_GRAY));
+            }
+
+            if (Plugin.getDefault().getImageRegistry().get(KEY_JAVA_PROJECT) == null) {
+                // use Java-Project image from JDT (unfortunately not shared by JDT-Plugin)
+                Image image = AbstractUIPlugin.imageDescriptorFromPlugin(JavaUI.ID_PLUGIN, "icons/full/eview16/projects.gif").createImage();
+                Plugin.getDefault().getImageRegistry().put(KEY_JAVA_PROJECT, image);
+                Plugin.getDefault().getImageRegistry().put(KEY_JAVA_PROJECT_GREYSCALE, new Image(Display.getCurrent(), image, SWT.IMAGE_GRAY));
+            }
+        }
+
+        @Override
+        public String getText(Object element) {
+            String text;
+            if (element instanceof File) {
+                text = ((File) element).getName() + " - configuration project";
+            } else {
+                text = ((Project) element).getName();
+            }
+
+            if (projectExistsInEclipse(element)) {
+                text = text + " (exits and will be updated)";
+            }
+            return text;
+        }
+
+        @Override
+        public Color getForeground(Object element) {
+            if (projectExistsInEclipse(element)) {
+                // maybe check for some "disabled" foreground to work better with theming
+                return Display.getCurrent().getSystemColor(SWT.COLOR_GRAY);
+            }
+            return super.getForeground(element);
+        }
+
+        @Override
+        public Image getImage(Object element) {
+            boolean projectExists = projectExistsInEclipse(element);
+            final Image image;
+            if (element instanceof File) {
+                if (projectExists) {
+                    image = Plugin.getDefault().getImageRegistry().get(KEY_GENERAL_PROJECT_GREYSCALE);
+                } else {
+                    image = Plugin.getDefault().getImageRegistry().get(KEY_GENERAL_PROJECT);
+                }
+            } else {
+                if (projectExists) {
+                    image = Plugin.getDefault().getImageRegistry().get(KEY_JAVA_PROJECT_GREYSCALE);
+                } else {
+                    image = Plugin.getDefault().getImageRegistry().get(KEY_JAVA_PROJECT);
+                }
+            }
+            return image;
+        }
+
+        private boolean projectExistsInEclipse(Object element) {
+            final IProject existingProject;
+            if (element instanceof File) {
+                File cnfFile = (File) element;
+                existingProject = ResourcesPlugin.getWorkspace().getRoot().getProject(cnfFile.getName());
+                return existingProject.exists() && existingProject.getLocation().toString().equals(cnfFile.toString());
+            }
+            Project project = (Project) element;
+            existingProject = ResourcesPlugin.getWorkspace().getRoot().getProject(project.getName());
+            return existingProject.exists() && existingProject.getLocation().toString().equals(project.getBase().toString());
+        }
+    }
+
+}


### PR DESCRIPTION
fixes bndtools/bndtools#916

Imports a bnd-workspace to Eclipse

Usage:

1. File -> Import...

1. BndTools -> Existing Bnd-Workspace

1. Choose a valid Bnd-Workspace root-folder

This importer will map informations from Bnd to Eclipse. To do so, **it will wipe all existing Eclipse project-specific settings in this workspace an recreate them**.

For each Bnd-project the import will make sure to set the correct source-, test-, and output-folders, where project level takes precedence over workspace-level settings.

Open
- Eclipse smart import (not sure if this is available in the current Eclipse 4.4.2 base)


This work is stalled since quite some time because I tried to display some more information in a read-only-panel (like mapped folders) but I wasnt very happy with this and couldnt find any better. So I just deleted this part.

Signed-off-by: Marc Schlegel <maschlegel@gmail.com>