### PR TITLE
Preference pages under Bndtools don't show when filtering for 'bnd'

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -689,6 +689,10 @@
       </shortcut>
 
    </extension>
+   
+   <extension point="org.eclipse.ui.keywords">
+      <keyword id="bndtools.core" label="Bndtools"/>
+   </extension>
 
     <extension
           point="org.eclipse.ui.preferencePages">
@@ -696,29 +700,35 @@
              class="bndtools.preferences.ui.BndPreferencePage"
              id="bndtools.prefPages.basic"
              name="Bndtools">
+             <keywordReference id="bndtools.core"/>
        </page>
        <page
              class="bndtools.preferences.ui.BndBuildPreferencePage"
              id="bndtools.prefPages.build"
              category="bndtools.prefPages.basic"
              name="Build">
+             <keywordReference id="bndtools.core"/>
        </page>
        <page
              class="bndtools.preferences.ui.ReposPreferencePage"
              id="bndtools.prefPages.repos"
              category="bndtools.prefPages.basic"
-             name="Repositories"/>
+             name="Repositories">
+             <keywordReference id="bndtools.core"/>
+       </page>
        <page
              class="bndtools.preferences.ui.GeneratedResourcesPreferencePage"
              id="bndtools.prefPages.generatedResources"
              category="bndtools.prefPages.basic"
              name="Generated Resources">
+             <keywordReference id="bndtools.core"/>
        </page>
        <page
              class="bndtools.preferences.ui.JpmPreferencePage"
              id="bndtools.prefPages.jpm"
              category="bndtools.prefPages.basic"
              name="JPM">
+             <keywordReference id="bndtools.core"/>
        </page>
     </extension>
 	<extension point="org.eclipse.ui.propertyPages">

--- a/org.bndtools.templating.gitrepo/resources/plugin.xml
+++ b/org.bndtools.templating.gitrepo/resources/plugin.xml
@@ -7,8 +7,8 @@
 			class="org.bndtools.templating.jgit.ui.GitRepoTemplatePreferencePage"
 			id="bndtools.prefPages.templating.gitRepos"
 			category="bndtools.prefPages.basic"
-			name="Workspace Template"
-			>
+			name="Workspace Template">
+			<keywordReference id="bndtools.core"/>
 		</page>
 	
 	</extension>


### PR DESCRIPTION
1598: Preference pages under Bndtools don't show when filtering for 'bnd'

fixes bndtools/bndtools#1598

Extensions-Points enhanced with keywords to include subpages in filter. Though Bndtools preferences are already at the root, showing subpages on filter is a expected behaviour in Eclipse.

Signed-off-by: Marc Schlegel maschlegel@gmail.com