### PR TITLE
Align key bindings to run/debug Bnd OSGi Tests

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -1010,7 +1010,7 @@
          commandId="bndtools.launch.runShortcut.debug"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
       <key
-         sequence="M3+M2+X C"
+         sequence="M3+M2+X K"
          contextId="org.eclipse.ui.globalScope"
          commandId="bndtools.launch.junitShortcut.run"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>


### PR DESCRIPTION
Change bindings extension to consistently use Alt+Shift+X/D K to run/debug tests.

See #1674: Different key bindings to run/debug Bnd OSGi Tests
Signed-off-by: Rüdiger Herrmann <ruediger.herrmann@gmx.de>