### PR TITLE
Add symlink support to Workspace template expansion.

### DIFF
--- a/bndtools.core/bndtools Cocoa 64-bit.launch
+++ b/bndtools.core/bndtools Cocoa 64-bit.launch
@@ -16,7 +16,7 @@
 <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="bndtools.core"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts -Xmx512m"/>
 <booleanAttribute key="trace" value="false"/>

--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
@@ -33,8 +33,10 @@ import org.bndtools.utils.workspace.FileUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jdt.core.IJavaProject;
@@ -45,6 +47,7 @@ import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.ui.IWorkbench;
 
 import aQute.bnd.build.Project;
+import aQute.lib.io.IO;
 import bndtools.Plugin;
 
 class NewBndProjectWizard extends AbstractNewBndProjectWizard {
@@ -197,8 +200,14 @@ class NewBndProjectWizard extends AbstractNewBndProjectWizard {
                         file.setCharset(resource.getTextEncoding(), progress.newChild(1));
                     }
                     break;
+                case Link :
+                    IFile linkFile = project.getFile(path);
+                    String linkTarget = IO.collect(resource.getContent(), resource.getTextEncoding());
+                    FileUtils.mkdirs(linkFile.getParent(), progress.newChild(1, SubMonitor.SUPPRESS_ALL_LABELS));
+                    linkFile.createLink(new Path(linkTarget), IResource.ALLOW_MISSING_LOCAL, progress.newChild(1, SubMonitor.SUPPRESS_ALL_LABELS));
+                    break;
                 default :
-                    throw new IllegalArgumentException("Unknown resource type " + resource.getType());
+                    throw new IllegalArgumentException("Unexpected resource type " + resource.getType());
                 }
             }
         } catch (Exception e) {

--- a/bndtools.core/src/bndtools/wizards/workspace/WorkspaceSetupWizard.java
+++ b/bndtools.core/src/bndtools/wizards/workspace/WorkspaceSetupWizard.java
@@ -120,6 +120,13 @@ public class WorkspaceSetupWizard extends Wizard implements INewWizard {
                             IO.copy(in, file);
                         }
                         break;
+                    case Link :
+                        File linkParentDir = file.getParentFile();
+                        Files.createDirectories(linkParentDir.toPath());
+                        String linkTargetPathStr = IO.collect(resource.getContent(), resource.getTextEncoding());
+                        Files.deleteIfExists(file.toPath());
+                        java.nio.file.Path linkPath = Files.createSymbolicLink(file.toPath(), new File(linkTargetPathStr).toPath());
+                        break;
                     default :
                         throw new IllegalArgumentException("Unknown resource type " + resource.getType());
                     }

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -16,3 +16,6 @@ com.google.guava:guava:16.0.1
 com.github.spullara.mustache.java:compiler:0.8.18
 
 org.antlr:ST4:jar:complete:4.0.8
+
+org.eclipse.jgit:org.eclipse.jgit:4.7.0.201704051617-r
+org.eclipse.jgit:org.eclipse.jgit.java7:3.7.1.201504261725-r

--- a/org.bndtools.templating.gitrepo/bnd.bnd
+++ b/org.bndtools.templating.gitrepo/bnd.bnd
@@ -1,11 +1,14 @@
 # This bundle separated from core as it has a dependency on JGit.
 
+
+
 -buildpath: \
 	${bndlib},\
 	bndtools.api; version=latest,\
 	org.bndtools.templating; version=latest,\
 	bndtools.utils; version=latest; packages=*,\
-	org.eclipse.jgit; version=3.4.2,\
+	org.eclipse.jgit; version=4.7.0,\
+	org.eclipse.jgit.java7; version=3.7.1,\
 	javaewah; version=0.7.9,\
 	com.jcraft.jsch; version=0.1.51,\
 	osgi.core;version=${osgi.core.version},\
@@ -17,9 +20,12 @@
 	org.eclipse.equinox.common,\
 	org.eclipse.core.commands
 
--privatepackage: org.bndtools.templating.jgit.*
+-privatepackage: \
+	org.bndtools.templating.jgit.*,\
+	org.eclipse.jgit.*
+
 -includeresource: resources
--conditionalpackage: aQute.lib.*, aQute.libg.*, org.bndtools.utils.*, org.eclipse.jgit.*, com.googlecode.javaewah
+-conditionalpackage: aQute.lib.*, aQute.libg.*, org.bndtools.utils.*, com.googlecode.javaewah
 
 Bundle-ActivationPolicy: lazy
 Bundle-SymbolicName: org.bndtools.templating.gitrepo; singleton:=true

--- a/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitCloneTemplate.java
+++ b/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitCloneTemplate.java
@@ -5,12 +5,14 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.bndtools.templating.FileResource;
 import org.bndtools.templating.FolderResource;
+import org.bndtools.templating.LinkResource;
 import org.bndtools.templating.ResourceMap;
 import org.bndtools.templating.Template;
 import org.bndtools.templating.util.ObjectClassDefinitionImpl;
@@ -204,7 +206,11 @@ public class GitCloneTemplate implements Template {
     }
 
     private static void recurse(String prefix, File file, FileFilter filter, ResourceMap resourceMap) {
-        if (file.isDirectory()) {
+        Path filePath = file.toPath();
+        if (Files.isSymbolicLink(filePath)) {
+            String path = prefix + file.getName();
+            resourceMap.put(path, new LinkResource(filePath));
+        } else if (file.isDirectory()) {
             String path = prefix + file.getName() + "/";
             resourceMap.put(path, new FolderResource());
 

--- a/org.bndtools.templating/src/org/bndtools/templating/LinkResource.java
+++ b/org.bndtools.templating/src/org/bndtools/templating/LinkResource.java
@@ -1,0 +1,34 @@
+package org.bndtools.templating;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LinkResource implements Resource {
+
+    private final Path path;
+
+    public LinkResource(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public ResourceType getType() {
+        return ResourceType.Link;
+    }
+
+    @Override
+    public InputStream getContent() throws IOException {
+        Path targetPath = Files.readSymbolicLink(path);
+        return new ByteArrayInputStream(targetPath.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String getTextEncoding() {
+        return StandardCharsets.UTF_8.name();
+    }
+
+}

--- a/org.bndtools.templating/src/org/bndtools/templating/ResourceType.java
+++ b/org.bndtools.templating/src/org/bndtools/templating/ResourceType.java
@@ -1,5 +1,5 @@
 package org.bndtools.templating;
 
 public enum ResourceType {
-    File, Folder;
+    File, Folder, Link;
 }

--- a/org.bndtools.templating/src/org/bndtools/templating/engine/mustache/MustacheTemplateEngine.java
+++ b/org.bndtools.templating/src/org/bndtools/templating/engine/mustache/MustacheTemplateEngine.java
@@ -118,6 +118,7 @@ public class MustacheTemplateEngine implements TemplateEngine {
                 Resource output;
                 switch (source.getType()) {
                 case Folder :
+                case Link :
                     output = source;
                     break;
                 case File :
@@ -132,7 +133,7 @@ public class MustacheTemplateEngine implements TemplateEngine {
                     }
                     break;
                 default :
-                    throw new IllegalArgumentException("Unknown resource type " + source.getType());
+                    throw new IllegalArgumentException("Unexpected resource type " + source.getType());
                 }
                 outputs.put(outputPath, output);
             }

--- a/org.bndtools.templating/src/org/bndtools/templating/engine/st/StringTemplateEngine.java
+++ b/org.bndtools.templating/src/org/bndtools/templating/engine/st/StringTemplateEngine.java
@@ -146,7 +146,7 @@ public class StringTemplateEngine implements TemplateEngine {
             Resource output;
 
             if (settings.ignore == null || !settings.ignore.matches(sourceName)) {
-                if (source.getType() == ResourceType.Folder) {
+                if (source.getType() == ResourceType.Folder || source.getType() == ResourceType.Link) {
                     output = source;
                 } else if (settings.preprocessMatch.matches(sourceName)) {
                     // This file is a candidate for preprocessing with ST


### PR DESCRIPTION
N.B. requires Java 8! Defer until after Bndtools 3.4.

Symlink support was added to JGit in version 4.7, in a separate library named “org.eclipse.jgit.java7”. Despite the name, that JAR contains class files with class version 52.0, i.e. they require Java 8.

Fixes #1657 [templates] new workspace doesn't understand symbolic links

Signed-off-by: Neil Bartlett <njbartlett@gmail.com>