### PR TITLE
Fix clicking "< Back" in New Bnd OSGi Project

### DIFF
--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
@@ -40,6 +40,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ui.wizards.NewJavaProjectWizardPageTwo;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.ui.IWorkbench;
@@ -81,6 +82,8 @@ class NewBndProjectWizard extends AbstractNewBndProjectWizard {
                 paramsPage.setTemplate(template);
             }
         });
+
+        setDefaultPageImageDescriptor(ImageDescriptor.createFromURL(Plugin.getDefault().getBundle().getEntry("icons/bndtools-wizban.png")));
     }
 
     @Override

--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizardPageTwo.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizardPageTwo.java
@@ -28,23 +28,8 @@ import bndtools.Plugin;
 
 public class NewBndProjectWizardPageTwo extends NewJavaProjectWizardPageTwo {
 
-    private boolean provisionalProjectCreated = false;
-
     public NewBndProjectWizardPageTwo(NewJavaProjectWizardPageOne pageOne) {
         super(pageOne);
-    }
-
-    @Override
-    public void setVisible(boolean visible) {
-        super.setVisible(visible);
-        if (visible) {
-            provisionalProjectCreated = true;
-        } else {
-            if (provisionalProjectCreated) {
-                removeProvisonalProject();
-                provisionalProjectCreated = false;
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
This was caused by an NPE when no provisional project was created. So
instead we just let the JDT project wizard take care of creating and
deleting the provisional project as necessary.

Fixes #1648

Signed-off-by: Sean Bright <sean.bright@gmail.com>