### PR TITLE
Use RepositoryPlugin::getName to get repository names where applicable

### DIFF
--- a/bndtools.core/src/bndtools/editor/project/RepositoriesEditModel.java
+++ b/bndtools.core/src/bndtools/editor/project/RepositoriesEditModel.java
@@ -14,6 +14,7 @@ import aQute.bnd.build.Workspace;
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.build.model.clauses.HeaderClause;
 import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.RepositoryPlugin;
 import bndtools.central.Central;
 
 class RepositoriesEditModel {
@@ -125,8 +126,16 @@ class RepositoriesEditModel {
         return out;
     }
 
-    private String toName(Repository r) {
-        return r.toString();
+    private String toName(Repository repo) {
+        if (repo instanceof aQute.bnd.deployer.repository.wrapper.Plugin) {
+            aQute.bnd.deployer.repository.wrapper.Plugin wrapper = (aQute.bnd.deployer.repository.wrapper.Plugin) repo;
+            wrapper.init();
+            return wrapper.toString();
+        }
+        if (repo instanceof RepositoryPlugin) {
+            return ((RepositoryPlugin) repo).getName();
+        }
+        return repo.toString();
     }
 
     private HeaderClause toHeaderClause(Repository repository) {

--- a/bndtools.core/src/bndtools/editor/project/RepositorySelectionPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RepositorySelectionPart.java
@@ -255,15 +255,15 @@ public class RepositorySelectionPart extends BndEditorPart {
                 Styler styler = null;
 
                 Repository repo = (Repository) element;
-                label = repo.toString();
-                if (repo instanceof RepositoryPlugin) {
-                    RepositoryPlugin repositoryPlugin = (RepositoryPlugin) repo;
-                    label = repositoryPlugin.getName();
-                } else if (repo instanceof aQute.bnd.deployer.repository.wrapper.Plugin) {
+                if (repo instanceof aQute.bnd.deployer.repository.wrapper.Plugin) {
                     @SuppressWarnings("resource")
                     aQute.bnd.deployer.repository.wrapper.Plugin wrapper = (aQute.bnd.deployer.repository.wrapper.Plugin) repo;
                     wrapper.init();
                     label = wrapper.toString();
+                } else if (repo instanceof RepositoryPlugin) {
+                    label = ((RepositoryPlugin) repo).getName();
+                } else {
+                    label = repo.toString();
                 }
                 image = repoImg;
 


### PR DESCRIPTION
Some RepositoryPlugin::toString returns stateful information of the repository so they won't
be picked up if you have ordered/selected repositories in .bnd(run) files

Signed-off-by: PK Søreide <per.kristian.soreide@gmail.com>

This PR requires https://github.com/bndtools/bnd/pull/2051 to be merged first