### PR TITLE
repoview: Clear cache when user refreshes repo

### DIFF
--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -433,12 +433,16 @@ public class Central implements IStartupParticipant {
         List<File> refreshedFiles = new ArrayList<File>();
         List<Refreshable> rps = getWorkspace().getPlugins(Refreshable.class);
         boolean changed = false;
+        boolean repoChanged = false;
         for (Refreshable rp : rps) {
             if (rp.refresh()) {
                 changed = true;
                 File root = rp.getRoot();
                 if (root != null)
                     refreshedFiles.add(root);
+                if (rp instanceof RepositoryPlugin) {
+                    repoChanged = true;
+                }
             }
         }
 
@@ -461,6 +465,9 @@ public class Central implements IStartupParticipant {
                         l.modelChanged(p);
                 }
 
+                if (repoChanged) {
+                    repositoriesViewRefresher.repositoriesRefreshed();
+                }
             } catch (Exception e) {
                 e.printStackTrace();
                 throw new RuntimeException(e);
@@ -476,6 +483,9 @@ public class Central implements IStartupParticipant {
                 p.setChanged();
                 for (ModelListener l : getInstance().listeners)
                     l.modelChanged(p);
+            }
+            if (plugin instanceof RepositoryPlugin) {
+                repositoriesViewRefresher.repositoryRefreshed((RepositoryPlugin) plugin);
             }
         }
     }

--- a/bndtools.core/src/bndtools/editor/project/RunFrameworkPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunFrameworkPart.java
@@ -30,6 +30,7 @@ import aQute.bnd.build.model.EE;
 import bndtools.BndConstants;
 import bndtools.utils.ModificationLock;
 import bndtools.editor.common.BndEditorPart;
+import bndtools.model.repo.LoadingContentElement;
 
 public class RunFrameworkPart extends BndEditorPart implements PropertyChangeListener {
     private static final String[] PROPERTIES = new String[] {
@@ -111,8 +112,12 @@ public class RunFrameworkPart extends BndEditorPart implements PropertyChangeLis
                 lock.ifNotModifying(new Runnable() {
                     @Override
                     public void run() {
-                        markDirty();
                         Object element = ((IStructuredSelection) frameworkViewer.getSelection()).getFirstElement();
+                        if (element instanceof LoadingContentElement) {
+                            return;
+                        }
+
+                        markDirty();
                         if (element == null)
                             selectedFramework = null;
                         else

--- a/bndtools.core/src/bndtools/model/repo/RepositoryTreeContentProvider.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryTreeContentProvider.java
@@ -36,6 +36,7 @@ import aQute.bnd.service.IndexProvider;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.ResolutionPhase;
 import aQute.bnd.version.Version;
+import bndtools.Plugin;
 import bndtools.central.Central;
 import bndtools.central.WorkspaceR5Repository;
 
@@ -283,13 +284,16 @@ public class RepositoryTreeContentProvider implements ITreeContentProvider {
 
                 @Override
                 protected IStatus run(IProgressMonitor monitor) {
+                    IStatus status = Status.OK_STATUS;
                     Object[] jobresult;
                     List<String> bsns = null;
 
                     try {
                         bsns = repoPlugin.list(wildcardFilter);
                     } catch (Exception e) {
-                        logger.logError(MessageFormat.format("Error querying repository {0}.", repoPlugin.getName()), e);
+                        String message = MessageFormat.format("Error querying repository {0}.", repoPlugin.getName());
+                        logger.logError(message, e);
+                        status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID, message, e);
                     }
                     if (bsns != null) {
                         Collections.sort(bsns);
@@ -310,7 +314,7 @@ public class RepositoryTreeContentProvider implements ITreeContentProvider {
                         });
                     }
 
-                    return Status.OK_STATUS;
+                    return status;
                 }
             };
             job.schedule();


### PR DESCRIPTION
The repoView has a cache of results now due to recent async work in
this commit ac4a86c5d9436ea6653cb15c44cde484d0308e1b

However this cache was not being cleared when user 'refreshes' repos
in either RepoView or main toolbar menu, this change addresses that

Closes https://github.com/bndtools/bndtools/pull/1719