### PR TITLE
[Baseline] Properly report Bundle-Version location

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/handlers/baseline/BundleVersionErrorHandler.java
+++ b/bndtools.builder/src/org/bndtools/builder/handlers/baseline/BundleVersionErrorHandler.java
@@ -27,6 +27,7 @@ import aQute.bnd.differ.Baseline.BundleInfo;
 import aQute.bnd.osgi.Builder;
 import aQute.lib.io.IO;
 import aQute.service.reporter.Report.Location;
+import bndtools.central.Central;
 
 public class BundleVersionErrorHandler extends AbstractBuildErrorDetailsHandler {
 
@@ -58,6 +59,35 @@ public class BundleVersionErrorHandler extends AbstractBuildErrorDetailsHandler 
                     // Not found in sub-bundle file, try bnd.bnd
                     bndFile = project.getFile(Project.BNDFILE);
                     loc = findBundleVersionHeader(bndFile);
+                }
+
+                if (loc == null) {
+                    // Not found in bnd.bnd, try build.bnd. Marker will appear on bnd.bnd
+                    IFile buildFile = Central.getWorkspaceBuildFile();
+                    loc = findBundleVersionHeader(buildFile);
+                    if (loc != null) {
+                        loc = new LineLocation();
+                        loc.lineNum = 1;
+                        loc.start = 1;
+                        loc.end = 1;
+                    }
+                }
+
+                if (loc == null) {
+                    // Not found in build.bnd, try included files. Marker will appear on bnd.bnd
+                    List<File> extensions = Central.getWorkspace().getIncluded();
+                    if (extensions != null) {
+                        for (File extension : extensions) {
+                            loc = findBundleVersionHeader((IFile) Central.toResource(extension));
+                            if (loc != null) {
+                                loc = new LineLocation();
+                                loc.lineNum = 1;
+                                loc.start = 1;
+                                loc.end = 1;
+                                break;
+                            }
+                        }
+                    }
                 }
 
                 if (loc != null) {


### PR DESCRIPTION
If Bundle-Version is defined in build.bnd or ext, no markers are created and the project will not build

The marker will be set on the Projects bnd.bnd file

Signed-off-by: PK Søreide <per.kristian.soreide@gmail.com>