### PR TITLE
Eliminate a potential infinite build loop with m2e

### DIFF
--- a/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
+++ b/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
@@ -7,13 +7,18 @@ import java.util.Set;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
+import org.bndtools.api.Logger;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ICallable;
@@ -48,9 +53,26 @@ public class BndConfigurator extends AbstractProjectConfigurator {
                 Job job = new WorkspaceJob("Executing " + project.getName() + " jar:jar goal") {
                     @Override
                     public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
-                        execJarMojo(projectFacade, monitor);
+                        SubMonitor progress = SubMonitor.convert(monitor, 2);
+                        execJarMojo(projectFacade, progress.newChild(1, SubMonitor.SUPPRESS_NONE));
 
-                        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+                        // Find the maven output directory (usually "target")
+                        MavenProject mvnProject = projectFacade.getMavenProject(); // won't return null because getMavenProject(ProgressMonitor) was called within execJarMojo
+                        IPath buildDirPath = Path.fromOSString(mvnProject.getBuild().getDirectory());
+                        IPath projectPath = project.getLocation();
+                        IPath relativeBuildDirPath = buildDirPath.makeRelativeTo(projectPath);
+                        IFolder buildDir = project.getFolder(relativeBuildDirPath);
+
+                        if (buildDir != null) {
+                            // TODO: there *may* be a remaining issue here if a source-generation plugin gets triggered by the above invocation of the jar:jar goal.
+                            // This could cause Eclipse to think that the Java sources are dirty and queue the project for rebuilding, thus entering an infinite loop.
+                            // One solution would be to find the output artifact jar and refresh ONLY that. However we have not been able to create the condition we
+                            // are worried about so we are deferring any extra work on this until it's shown to be a real problem.
+                            buildDir.refreshLocal(IResource.DEPTH_INFINITE, progress.newChild(1));
+                        } else {
+                            Logger.getLogger(BndConfigurator.class).logError(String.format("Project build folder '%s' does not exist, or is not a child of the project path '%s'", buildDirPath, projectPath), null);
+                            progress.worked(1);
+                        }
 
                         return Status.OK_STATUS;
                     }


### PR DESCRIPTION
The bndtools-m2e plugin created a build loop with certain projects that produced generated Java sources into src/main. The triggering of the jar:jar goal inside BndConfigurator caused sources to regenerate and Eclipse to believe that the project was dirty. This re-enqueued the same project for building, thus creating an infinite loop.

This patch ensures that only the target directory is refreshed. There may be a remaining issue with source generators that generate into `target/generated-sources` but we have been unable to simulate such an issue. It seems that most well-behaved source generator plugins do not get triggered by the jar:jar goal.

Signed-off-by: Neil Bartlett <njbartlett@gmail.com>