### PR TITLE
Enable ui decorators when using Maven to build

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndProjectInfoAdapter.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndProjectInfoAdapter.java
@@ -1,0 +1,39 @@
+package org.bndtools.builder;
+
+import java.io.File;
+import java.util.Collection;
+
+import org.bndtools.build.api.IProjectDecorator.BndProjectInfo;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.osgi.Packages;
+
+public class BndProjectInfoAdapter implements BndProjectInfo {
+
+    private final Project project;
+
+    public BndProjectInfoAdapter(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public Collection<File> getSourcePath() throws Exception {
+        return project.getSourcePath();
+    }
+
+    @Override
+    public Packages getExports() {
+        return project.getExports();
+    }
+
+    @Override
+    public Packages getImports() {
+        return project.getImports();
+    }
+
+    @Override
+    public Packages getContained() {
+        return project.getContained();
+    }
+
+}

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -269,9 +269,11 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
                         }
 
                         // We can now decorate based on the build we just did.
-                        PackageDecorator.updateDecoration(myProject, model);
+                        BndProjectInfoAdapter adapter = new BndProjectInfoAdapter(model);
 
-                        ComponentMarker.updateComponentMarkers(myProject, model);
+                        PackageDecorator.updateDecoration(myProject, adapter);
+
+                        ComponentMarker.updateComponentMarkers(myProject, adapter);
 
                         if (model.isCnf()) {
                             model.getWorkspace().refresh(); // this is for bnd plugins built in cnf

--- a/bndtools.builder/src/org/bndtools/builder/BuilderPlugin.java
+++ b/bndtools.builder/src/org/bndtools/builder/BuilderPlugin.java
@@ -1,5 +1,7 @@
 package org.bndtools.builder;
 
+import org.bndtools.build.api.IProjectDecorator;
+import org.bndtools.builder.decorator.ui.ProjectDecoratorImpl;
 import org.osgi.framework.BundleContext;
 
 public class BuilderPlugin extends org.eclipse.core.runtime.Plugin {
@@ -18,6 +20,7 @@ public class BuilderPlugin extends org.eclipse.core.runtime.Plugin {
         synchronized (BuilderPlugin.class) {
             instance = this;
         }
+        context.registerService(IProjectDecorator.class, new ProjectDecoratorImpl(), null);
     }
 
     @Override

--- a/bndtools.builder/src/org/bndtools/builder/ComponentMarker.java
+++ b/bndtools.builder/src/org/bndtools/builder/ComponentMarker.java
@@ -4,6 +4,7 @@ import java.io.File;
 import org.bndtools.api.BndtoolsConstants;
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
+import org.bndtools.build.api.IProjectDecorator.BndProjectInfo;
 import org.bndtools.builder.decorator.ui.ComponentDecorator;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -27,8 +28,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IDecoratorManager;
 import org.eclipse.ui.PlatformUI;
 
-import aQute.bnd.build.Project;
-
 /**
  * This class creates markers for classes that contain the {@link org.osgi.service.component.annotations.Component}
  * annotation, and stores this information in the {@link BuilderPlugin} for use by {@link ComponentDecorator}and
@@ -42,7 +41,7 @@ public class ComponentMarker {
     public static final String ANNOTATION_COMPONENT_PACKAGE = "org.osgi.service.component.annotations";
     public static final String ANNOTATION_COMPONENT_FQN = ANNOTATION_COMPONENT_PACKAGE + ".Component";
 
-    public static void updateComponentMarkers(IProject project, Project model) throws Exception {
+    public static void updateComponentMarkers(IProject project, BndProjectInfo model) throws Exception {
         try {
             if (!project.isOpen()) {
                 return;
@@ -50,9 +49,6 @@ public class ComponentMarker {
             IJavaProject javaProject = JavaCore.create(project);
             if (javaProject == null) {
                 return; // project is not a java project
-            }
-            if (!project.getProject().hasNature(BndtoolsConstants.NATURE_ID)) {
-                return; // project is not a bndtools project
             }
 
             for (IClasspathEntry cpe : javaProject.getRawClasspath()) {

--- a/bndtools.builder/src/org/bndtools/builder/decorator/ui/ComponentDecorator.java
+++ b/bndtools.builder/src/org/bndtools/builder/decorator/ui/ComponentDecorator.java
@@ -38,9 +38,6 @@ public class ComponentDecorator extends LabelProvider implements ILightweightLab
             if (element instanceof CompilationUnit) {
 
                 CompilationUnit unit = (CompilationUnit) element;
-                if (!unit.getJavaProject().getProject().hasNature(BndtoolsConstants.NATURE_ID)) {
-                    return;
-                }
                 if (!isComponentInImports(unit)) {
                     return;
                 }
@@ -77,9 +74,6 @@ public class ComponentDecorator extends LabelProvider implements ILightweightLab
 
             } else if (element instanceof SourceType) {
                 SourceType type = (SourceType) element;
-                if (!type.getJavaProject().getProject().hasNature(BndtoolsConstants.NATURE_ID)) {
-                    return;
-                }
 
                 if (!isComponentInImports(type.getCompilationUnit())) {
                     return;
@@ -108,9 +102,6 @@ public class ComponentDecorator extends LabelProvider implements ILightweightLab
                 }
             } else if (element instanceof IPackageFragment) {
                 IPackageFragment frag = (IPackageFragment) element;
-                if (!frag.getJavaProject().getProject().hasNature(BndtoolsConstants.NATURE_ID)) {
-                    return;
-                }
                 IResource resource = (IResource) frag.getAdapter(IResource.class);
                 if (resource != null && countComponents(resource)) {
                     decoration.addOverlay(componentIcon);

--- a/bndtools.builder/src/org/bndtools/builder/decorator/ui/PackageDecorator.java
+++ b/bndtools.builder/src/org/bndtools/builder/decorator/ui/PackageDecorator.java
@@ -2,9 +2,9 @@ package org.bndtools.builder.decorator.ui;
 
 import java.io.File;
 
-import org.bndtools.api.BndtoolsConstants;
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
+import org.bndtools.build.api.IProjectDecorator.BndProjectInfo;
 import org.bndtools.builder.BndtoolsBuilder;
 import org.bndtools.utils.swt.SWTConcurrencyUtil;
 import org.eclipse.core.resources.IProject;
@@ -25,7 +25,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 
-import aQute.bnd.build.Project;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.version.Version;
 
@@ -49,9 +48,6 @@ public class PackageDecorator extends LabelProvider implements ILightweightLabel
             if (pkg.getKind() != IPackageFragmentRoot.K_SOURCE) {
                 return;
             }
-            if (!pkg.getJavaProject().getProject().hasNature(BndtoolsConstants.NATURE_ID)) {
-                return;
-            }
             IResource pkgResource = pkg.getCorrespondingResource();
             if (pkgResource == null) {
                 return;
@@ -71,7 +67,7 @@ public class PackageDecorator extends LabelProvider implements ILightweightLabel
         }
     }
 
-    public static void updateDecoration(IProject project, Project model) throws Exception {
+    public static void updateDecoration(IProject project, BndProjectInfo model) throws Exception {
         if (!project.isOpen()) {
             return;
         }

--- a/bndtools.builder/src/org/bndtools/builder/decorator/ui/ProjectDecoratorImpl.java
+++ b/bndtools.builder/src/org/bndtools/builder/decorator/ui/ProjectDecoratorImpl.java
@@ -1,0 +1,15 @@
+package org.bndtools.builder.decorator.ui;
+
+import org.bndtools.build.api.IProjectDecorator;
+import org.bndtools.builder.ComponentMarker;
+import org.eclipse.core.resources.IProject;
+
+public class ProjectDecoratorImpl implements IProjectDecorator {
+
+    @Override
+    public void updateDecoration(IProject project, BndProjectInfo model) throws Exception {
+        PackageDecorator.updateDecoration(project, model);
+        ComponentMarker.updateComponentMarkers(project, model);
+    }
+
+}

--- a/bndtools.core/src/org/bndtools/build/api/IProjectDecorator.java
+++ b/bndtools.core/src/org/bndtools/build/api/IProjectDecorator.java
@@ -1,0 +1,24 @@
+package org.bndtools.build.api;
+
+import java.io.File;
+import java.util.Collection;
+
+import org.eclipse.core.resources.IProject;
+
+import aQute.bnd.osgi.Packages;
+
+public interface IProjectDecorator {
+
+    void updateDecoration(IProject project, BndProjectInfo info) throws Exception;
+
+    static interface BndProjectInfo {
+        Collection<File> getSourcePath() throws Exception;
+
+        public Packages getExports();
+
+        public Packages getImports();
+
+        public Packages getContained();
+    }
+
+}

--- a/bndtools.core/src/org/bndtools/build/api/packageinfo
+++ b/bndtools.core/src/org/bndtools/build/api/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
+++ b/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
@@ -1,13 +1,20 @@
 package bndtools.m2e;
 
+import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.maven.lifecycle.MavenExecutionPlan;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
+import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
+import org.bndtools.build.api.IProjectDecorator;
+import org.bndtools.build.api.IProjectDecorator.BndProjectInfo;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -33,8 +40,57 @@ import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
 import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionBuildParticipant;
 import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Packages;
 
 public class BndConfigurator extends AbstractProjectConfigurator {
+
+    ILogger logger = Logger.getLogger(BndConfigurator.class);
+
+    public static class MavenProjectInfo implements BndProjectInfo {
+
+        private final MavenProject project;
+
+        private final Analyzer analyzer;
+
+        public MavenProjectInfo(MavenProject project) throws Exception {
+            super();
+            this.project = project;
+            String type = project.getArtifact().getType();
+            File outputFile = new File(project.getBuild().getDirectory(), project.getBuild().getFinalName() + "." + (type == null ? "jar" : type));
+            analyzer = new Analyzer(new Jar(outputFile));
+            analyzer.analyze();
+        }
+
+        @Override
+        public Collection<File> getSourcePath() throws Exception {
+            List<File> sourcePath = new ArrayList<>();
+            for (String path : project.getCompileSourceRoots()) {
+                sourcePath.add(new File(path));
+            }
+            return sourcePath;
+        }
+
+        @Override
+        public Packages getExports() {
+            return analyzer.getExports();
+        }
+
+        @Override
+        public Packages getImports() {
+            return analyzer.getImports();
+        }
+
+        @Override
+        public Packages getContained() {
+            return analyzer.getContained();
+        }
+
+    }
 
     @Override
     public void configure(ProjectConfigurationRequest request, IProgressMonitor monitor) throws CoreException {}
@@ -121,9 +177,34 @@ public class BndConfigurator extends AbstractProjectConfigurator {
                     }
                 }
 
+                // We can now decorate based on the build we just did.
+                try {
+                    IProjectDecorator decorator = Injector.ref.get();
+                    if (decorator != null) {
+                        BndProjectInfo info = new MavenProjectInfo(mavenProject);
+                        decorator.updateDecoration(projectFacade.getProject(), info);
+                    }
+                } catch (Exception e) {
+                    logger.logError("Failed to decorate project " + projectFacade.getProject().getName(), e);
+                }
+
                 return null;
             }
         }, monitor);
     }
 
+    @Component
+    public static class Injector {
+
+        private static AtomicReference<IProjectDecorator> ref = new AtomicReference<IProjectDecorator>();
+
+        @Reference
+        void setDecorator(IProjectDecorator decorator) {
+            ref.set(decorator);
+        }
+
+        void unsetDecorator(IProjectDecorator decorator) {
+            ref.compareAndSet(decorator, null);
+        }
+    }
 }

--- a/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
+++ b/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
@@ -60,9 +60,11 @@ public class BndConfigurator extends AbstractProjectConfigurator {
         public MavenProjectInfo(MavenProject project) throws Exception {
             super();
             this.project = project;
-            String type = project.getArtifact().getType();
-            File outputFile = new File(project.getBuild().getDirectory(), project.getBuild().getFinalName() + "." + (type == null ? "jar" : type));
-            analyzer = new Analyzer(new Jar(outputFile));
+            File file = project.getArtifact().getFile();
+            if (file == null) {
+                throw new IllegalStateException("The output file for project " + project.getName() + " does not exist");
+            }
+            analyzer = new Analyzer(new Jar(file));
             analyzer.analyze();
         }
 


### PR DESCRIPTION
The Bndtools builder adds useful decorations to exported packages, and to files which declare OSGi components. This should be exended to include the maven build as well.

Signed-off-by: Tim Ward <timothyjward@apache.org>