### PR TITLE
Fix Build All

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -179,6 +179,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
                             String changed = ""; // if empty, no change
                             String del = "";
                             if (requestClasspathContainerUpdate()) {
+                                needRebuild();
                                 changed += "Classpath container updated";
                                 del = " & ";
                             }

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -93,12 +93,12 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
     @Override
     protected IProject[] build(final int kind, Map<String,String> args, final IProgressMonitor monitor) throws CoreException {
 
+        final IProject myProject = getProject();
         BndPreferences prefs = new BndPreferences();
-        buildLog = new BuildLogger(prefs.getBuildLogging());
+        buildLog = new BuildLogger(prefs.getBuildLogging(), myProject.getName(), kind);
 
         final BuildListeners listeners = new BuildListeners();
 
-        final IProject myProject = getProject();
         try {
 
             listeners.fireBuildStarting(myProject);
@@ -290,7 +290,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
             throw new CoreException(new Status(IStatus.ERROR, PLUGIN_ID, 0, "Build Error!", e));
         } finally {
             if (buildLog.isActive())
-                logger.logInfo(buildLog.toString(myProject.getName()), null);
+                logger.logInfo(buildLog.format(), null);
             listeners.release(myProject);
         }
     }

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -17,20 +17,16 @@ import org.bndtools.api.Logger;
 import org.bndtools.builder.classpath.BndContainerInitializer;
 import org.bndtools.builder.decorator.ui.PackageDecorator;
 import org.bndtools.utils.workspace.WorkspaceUtils;
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IJavaProject;
@@ -80,8 +76,8 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
     private boolean postponed;
 
     /**
-     * Called from Eclipse when it thinks this project should be build. We're proposed to figure out if we've changed
-     * and then build as quickly as possible.
+     * Called from Eclipse when it thinks this project should be build. We're proposed to figure out if we've changed and
+     * then build as quickly as possible.
      * <p>
      * We ensure we're called in proper order defined by bnd, if not we will make it be called in proper order.
      *
@@ -344,8 +340,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
             }
 
             // Tell Eclipse what we did...
-            IFolder targetFolder = myProject.getFolder(calculateTargetDirPath(model));
-            targetFolder.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+            Central.refreshFile(model.getTarget(), monitor, true);
         } catch (Exception e) {
             throw new CoreException(new Status(IStatus.ERROR, PLUGIN_ID, 0, "Build Error!", e));
         }
@@ -380,8 +375,8 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
      * Check if the classpath container this project needs to be updated.
      *
      * @return {@code true} if this project has a bnd classpath container and a classpath update should be requested.
-     *         {@code false} if this project does not have a bnd classpath container or a classpath update does not need
-     *         to be requested.
+     *         {@code false} if this project does not have a bnd classpath container or a classpath update does not need to
+     *         be requested.
      */
     private boolean suggestClasspathContainerUpdate() throws Exception {
         IJavaProject javaProject = JavaCore.create(getProject());
@@ -397,8 +392,8 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
      * <p>
      * The classpath container may have added errors to the model which the caller must check for.
      *
-     * @return {@code true} if this project has a bnd classpath container and the classpath was changed. {@code false}
-     *         if this project does not have a bnd classpath container or the classpath was not changed.
+     * @return {@code true} if this project has a bnd classpath container and the classpath was changed. {@code false} if
+     *         this project does not have a bnd classpath container or the classpath was not changed.
      */
     private boolean requestClasspathContainerUpdate() throws CoreException {
         IJavaProject javaProject = JavaCore.create(getProject());
@@ -442,12 +437,6 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
                     IO.delete(f);
             }
         IO.delete(new File(model.getTarget(), Project.BUILDFILES));
-    }
-
-    private static IPath calculateTargetDirPath(Project model) throws Exception {
-        IPath basePath = Path.fromOSString(model.getBase().getAbsolutePath());
-        final IPath targetDirPath = Path.fromOSString(model.getTarget().getAbsolutePath()).makeRelativeTo(basePath);
-        return targetDirPath;
     }
 
     private IProject[] calculateDependsOn(Project model) throws Exception {

--- a/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
+++ b/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
@@ -2,19 +2,42 @@ package org.bndtools.builder;
 
 import java.util.Formatter;
 
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+
 public class BuildLogger {
     public static final int LOG_FULL = 2;
     public static final int LOG_BASIC = 1;
     public static final int LOG_NONE = 0;
     private final int level;
+    private final String name;
+    private final String kind;
     private final long start = System.currentTimeMillis();
     private final StringBuilder sb = new StringBuilder();
     private final Formatter formatter = new Formatter(sb);
     private boolean used = false;
     private int files = -1;
 
-    public BuildLogger(int level) {
+    public BuildLogger(int level, String name, int kind) {
         this.level = level;
+        this.name = name;
+        switch (kind) {
+        case IncrementalProjectBuilder.FULL_BUILD :
+            this.kind = "FULL";
+            break;
+        case IncrementalProjectBuilder.AUTO_BUILD :
+            this.kind = "AUTO";
+            break;
+        case IncrementalProjectBuilder.CLEAN_BUILD :
+            this.kind = "CLEAN";
+            break;
+        case IncrementalProjectBuilder.INCREMENTAL_BUILD :
+            this.kind = "INCREMENTAL";
+            break;
+        default :
+            this.kind = String.valueOf(kind);
+            break;
+        }
+
     }
 
     public void basic(String string) {
@@ -58,16 +81,16 @@ public class BuildLogger {
         sb.append('\n');
     }
 
-    public String toString(String name) {
+    public String format() {
         long end = System.currentTimeMillis();
         full("Duration %.2f sec", (end - start) / 1000f);
 
         StringBuilder top = new StringBuilder();
         try (Formatter topper = new Formatter(top)) {
             if (files > 0)
-                topper.format("BUILD %s %d file%s built", name, files, files > 1 ? "s were" : " was");
+                topper.format("BUILD %s %s %d file%s built", kind, name, files, files > 1 ? "s were" : " was");
             else
-                topper.format("BUILD %s no build", name);
+                topper.format("BUILD %s %s no build", kind, name);
         }
 
         return top.append('\n').append(sb).toString();

--- a/bndtools.builder/src/org/bndtools/builder/CnfWatcher.java
+++ b/bndtools.builder/src/org/bndtools/builder/CnfWatcher.java
@@ -77,7 +77,7 @@ public class CnfWatcher implements IResourceChangeListener {
                 return;
 
             Project p = allProjects.iterator().next();
-            DeltaWrapper dw = new DeltaWrapper(p, delta, new BuildLogger(0));
+            DeltaWrapper dw = new DeltaWrapper(p, delta, new BuildLogger(BuildLogger.LOG_NONE, "", 0));
             if (dw.hasCnfChanged()) {
                 workspace.clear();
                 workspace.forceRefresh();

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
@@ -1,22 +1,20 @@
 package org.bndtools.builder.classpath;
 
 import java.io.Serializable;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.bndtools.api.BndtoolsConstants;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 
 public class BndContainer implements IClasspathContainer, Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
     public static final String DESCRIPTION = "Bnd Bundle Path";
     private final IClasspathEntry[] entries;
-    private final AtomicLong lastModified;
+    private final long lastModified;
 
     BndContainer(IClasspathEntry[] entries, long lastModified) {
         this.entries = entries;
-        this.lastModified = new AtomicLong(lastModified);
+        this.lastModified = lastModified;
     }
 
     @Override
@@ -45,15 +43,6 @@ public class BndContainer implements IClasspathContainer, Serializable {
     }
 
     long lastModified() {
-        return lastModified.get();
-    }
-
-    boolean updateLastModified(long time) {
-        for (long current = lastModified.get(); time > current; current = lastModified.get()) {
-            if (lastModified.compareAndSet(current, time)) {
-                return true;
-            }
-        }
-        return false;
+        return lastModified;
     }
 }

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -195,7 +195,6 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
         try {
             return serializationHelper.readClasspathContainer(containerFile);
         } catch (IOException | ClassNotFoundException e) {
-            logger.logError("Unable to load stored classpath container", e);
             return new BndContainer(Updater.EMPTY_ENTRIES, 0L);
         }
     }
@@ -272,12 +271,8 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
                 if (container instanceof BndContainer) {
                     BndContainer bndContainer = (BndContainer) container;
                     List<IClasspathEntry> currentClasspath = Arrays.asList(bndContainer.getClasspathEntries());
-                    if (newClasspath.equals(currentClasspath)) {
-                        if (bndContainer.updateLastModified(lastModified)) {
-                            storeClasspathContainer(project, bndContainer);
-                            refreshFiles(filesToRefresh);
-                        }
-                        return; // no change; so no need to set entries
+                    if (newClasspath.equals(currentClasspath) && (lastModified <= bndContainer.lastModified())) {
+                        return; // no change; so no need for new container
                     }
                 }
             }
@@ -345,7 +340,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
             BndPreferences prefs = new BndPreferences();
             if (prefs.getBuildLogging() == BuildLogger.LOG_FULL) {
                 StringBuilder sb = new StringBuilder();
-                sb.append("ClasspathEntries ").append(javaProject.getProject().getName());
+                sb.append(container.getDescription()).append(" for ").append(javaProject.getProject().getName());
                 for (IClasspathEntry cpe : container.getClasspathEntries()) {
                     sb.append("\n--- ").append(cpe);
                 }

--- a/bndtools.builder/src/org/bndtools/builder/decorator/ui/ComponentDecorator.java
+++ b/bndtools.builder/src/org/bndtools/builder/decorator/ui/ComponentDecorator.java
@@ -131,7 +131,7 @@ public class ComponentDecorator extends LabelProvider implements ILightweightLab
     private static boolean isComponentInImports(ICompilationUnit unit) throws CoreException {
         boolean annotationInImports = false;
 
-        if (unit != null) {
+        if ((unit != null) && unit.exists()) {
             for (IImportDeclaration importDecl : unit.getImports()) {
                 annotationInImports = importDecl.getElementName().equals(ComponentMarker.ANNOTATION_COMPONENT_FQN) || importDecl.getElementName().equals(ComponentMarker.ANNOTATION_COMPONENT_PACKAGE + ".*");
                 if (annotationInImports) {

--- a/bndtools.builder/src/org/bndtools/builder/handlers/baseline/BundleVersionErrorHandler.java
+++ b/bndtools.builder/src/org/bndtools/builder/handlers/baseline/BundleVersionErrorHandler.java
@@ -16,6 +16,7 @@ import org.bndtools.utils.parse.properties.PropertiesLineReader;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.contentassist.CompletionProposal;
@@ -80,7 +81,7 @@ public class BundleVersionErrorHandler extends AbstractBuildErrorDetailsHandler 
                         List<File> extensions = Central.getWorkspace().getIncluded();
                         if (extensions != null) {
                             for (File extension : extensions) {
-                                loc = findBundleVersionHeader((IFile) Central.toResource(extension));
+                                loc = findBundleVersionHeader(Central.toResource(extension));
                                 if (loc != null) {
                                     loc = new LineLocation();
                                     loc.lineNum = 1;
@@ -118,7 +119,7 @@ public class BundleVersionErrorHandler extends AbstractBuildErrorDetailsHandler 
         return result;
     }
 
-    private LineLocation findBundleVersionHeader(IFile bndFile) throws Exception {
+    private LineLocation findBundleVersionHeader(IResource bndFile) throws Exception {
         File file = bndFile.getLocation().toFile();
         String content = IO.collect(file);
 

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -544,11 +544,13 @@ public class Central implements IStartupParticipant {
 
     public static IResource toResource(File file) {
         IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        IFile[] ifiles = root.findFilesForLocationURI(file.toURI());
-        if (ifiles == null || ifiles.length == 0)
+        IFile[] ifiles = root.findFilesForLocationURI(file.getAbsoluteFile().toURI());
+        if ((ifiles == null) || (ifiles.length == 0)) {
             return null;
-
-        return ifiles[0];
+        }
+        IPath path = ifiles[0].getFullPath();
+        IResource resource = file.isDirectory() ? root.getFolder(path) : root.getFile(path);
+        return resource;
     }
 
     /**

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -422,7 +422,7 @@ public class Central implements IStartupParticipant {
                 p = p.removeLastSegments(1);
                 IResource resource = ResourcesPlugin.getWorkspace().getRoot().findMember(p);
                 if (resource != null) {
-                    resource.refreshLocal(2, null);
+                    resource.refreshLocal(IResource.DEPTH_INFINITE, null);
                     return;
                 }
             }
@@ -493,10 +493,18 @@ public class Central implements IStartupParticipant {
     }
 
     public static void refreshFile(File f) throws Exception {
-        String path = toLocal(f);
-        IResource r = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
-        if (r != null) {
-            r.refreshLocal(IResource.DEPTH_INFINITE, null);
+        refreshFile(f, null, false);
+    }
+
+    public static void refreshFile(File file, IProgressMonitor monitor, boolean derived) throws Exception {
+        IResource target = toResource(file);
+        if (target == null) {
+            return;
+        }
+        int depth = target.getType() == IResource.FILE ? IResource.DEPTH_ZERO : IResource.DEPTH_INFINITE;
+        if (!target.isSynchronized(depth)) {
+            target.refreshLocal(depth, monitor);
+            target.setDerived(derived, monitor);
         }
     }
 
@@ -504,15 +512,6 @@ public class Central implements IStartupParticipant {
         IJavaProject jp = getJavaProject(p);
         if (jp != null)
             jp.getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
-    }
-
-    private static String toLocal(File f) throws Exception {
-        String root = getWorkspace().getBase().getAbsolutePath();
-        String path = f.getAbsolutePath();
-        if (path.startsWith(root))
-            return f.getAbsolutePath().substring(root.length());
-
-        return path;
     }
 
     public void close() {

--- a/bndtools.core/src/bndtools/central/WorkspaceListener.java
+++ b/bndtools.core/src/bndtools/central/WorkspaceListener.java
@@ -4,12 +4,8 @@ import java.io.File;
 
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
-import org.osgi.util.promise.Promise;
-import org.osgi.util.promise.Success;
-
 import aQute.bnd.build.Workspace;
 import aQute.bnd.service.BndListener;
-import aQute.service.reporter.Reporter;
 
 public final class WorkspaceListener extends BndListener {
     private static final ILogger logger = Logger.getLogger(WorkspaceListener.class);
@@ -19,32 +15,9 @@ public final class WorkspaceListener extends BndListener {
     @Override
     public void changed(final File file) {
         try {
-            final RefreshFileJob job = new RefreshFileJob(file, true);
-            if (job.needsToSchedule()) {
-                Central.onWorkspaceInit(new Success<Workspace,Void>() {
-                    @Override
-                    public Promise<Void> call(Promise<Workspace> resolved) throws Exception {
-                        job.schedule();
-                        return null;
-                    }
-                });
-            }
+            Central.refreshFile(file, null, true);
         } catch (Exception e) {
-            logger.logError("Error refreshing workspace", e);
+            logger.logError("Error refreshing file " + file, e);
         }
     }
-
-    @Override
-    public void signal(Reporter reporter) {
-        //        errorProcessor.clear();
-        //        errorProcessor.getInfo(workspace);
-        //
-        //        for (String warning : errorProcessor.getWarnings()) {
-        //            logger.logWarning(warning, null);
-        //        }
-        //        for (String error : errorProcessor.getErrors()) {
-        //            logger.logError(error, null);
-        //        }
-    }
-
 }


### PR DESCRIPTION
The Bndtools Builder and Build All (when Build Automatically is off) did not work.

When a project depended on the generated jar of another project, the project's java builder did not rebuild when the dependent jar was built. So the project's build was broken.

These changes fix the Bndtools Builder to properly work with Build All.