### PR TITLE
Builder performance boost

### DIFF
--- a/bndtools.builder/_plugin.xml
+++ b/bndtools.builder/_plugin.xml
@@ -31,6 +31,17 @@
 		</builder>
 	</extension>
 
+	<extension
+		point="org.eclipse.jdt.core.compilationParticipant"
+		name="Bnd Container Compilation Participant"
+		>
+		<compilationParticipant class="org.bndtools.builder.classpath.BndContainerCompilationParticipant"
+			id="bndtools.builder.classpath.compilationparticipant"
+			modifiesEnvironment="true"
+			>
+		</compilationParticipant>
+	</extension>
+
 	<extension point="org.eclipse.ui.decorators">
 		<decorator
 			id="bndtools.packageDecorator"

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -316,12 +316,13 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
         BndPreferences prefs = new BndPreferences();
         buildLog = new BuildLogger(prefs.getBuildLogging(), myProject.getName(), CLEAN_BUILD);
         try {
+            MarkerSupport markers = new MarkerSupport(myProject);
+            markers.deleteMarkers("*");
+
             final Project model;
             try {
                 model = Central.getProject(myProject);
             } catch (Exception e) {
-                MarkerSupport markers = new MarkerSupport(myProject);
-                markers.deleteMarkers("*");
                 markers.createMarker(null, IMarker.SEVERITY_ERROR, "Cannot find bnd project", BndtoolsConstants.MARKER_BND_PATH_PROBLEM);
                 return;
             }

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -123,7 +123,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
                 return Central.bndCall(new Callable<IProject[]>() {
                     @Override
                     public IProject[] call() throws Exception {
-                        boolean force = kind == FULL_BUILD || kind == CLEAN_BUILD;
+                        boolean force = kind == FULL_BUILD;
                         model.clear();
 
                         DeltaWrapper delta = new DeltaWrapper(model, getDelta(myProject), buildLog);
@@ -312,9 +312,10 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
      */
     @Override
     protected void clean(IProgressMonitor monitor) throws CoreException {
+        IProject myProject = getProject();
+        BndPreferences prefs = new BndPreferences();
+        buildLog = new BuildLogger(prefs.getBuildLogging(), myProject.getName(), CLEAN_BUILD);
         try {
-            IProject myProject = getProject();
-
             final Project model;
             try {
                 model = Central.getProject(myProject);
@@ -344,6 +345,9 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
             Central.refreshFile(model.getTarget(), monitor, true);
         } catch (Exception e) {
             throw new CoreException(new Status(IStatus.ERROR, PLUGIN_ID, 0, "Build Error!", e));
+        } finally {
+            if (buildLog.isActive())
+                logger.logInfo(buildLog.format(), null);
         }
     }
 

--- a/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
+++ b/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
@@ -10,7 +10,7 @@ public class BuildLogger {
     public static final int LOG_NONE = 0;
     private final int level;
     private final String name;
-    private final String kind;
+    private final int kind;
     private final long start = System.currentTimeMillis();
     private final StringBuilder sb = new StringBuilder();
     private final Formatter formatter = new Formatter(sb);
@@ -20,24 +20,7 @@ public class BuildLogger {
     public BuildLogger(int level, String name, int kind) {
         this.level = level;
         this.name = name;
-        switch (kind) {
-        case IncrementalProjectBuilder.FULL_BUILD :
-            this.kind = "FULL";
-            break;
-        case IncrementalProjectBuilder.AUTO_BUILD :
-            this.kind = "AUTO";
-            break;
-        case IncrementalProjectBuilder.CLEAN_BUILD :
-            this.kind = "CLEAN";
-            break;
-        case IncrementalProjectBuilder.INCREMENTAL_BUILD :
-            this.kind = "INCREMENTAL";
-            break;
-        default :
-            this.kind = String.valueOf(kind);
-            break;
-        }
-
+        this.kind = kind;
     }
 
     public void basic(String string) {
@@ -84,13 +67,31 @@ public class BuildLogger {
     public String format() {
         long end = System.currentTimeMillis();
         full("Duration %.2f sec", (end - start) / 1000f);
+        String kindString;
+        switch (kind) {
+        case IncrementalProjectBuilder.FULL_BUILD :
+            kindString = "FULL";
+            break;
+        case IncrementalProjectBuilder.AUTO_BUILD :
+            kindString = "AUTO";
+            break;
+        case IncrementalProjectBuilder.CLEAN_BUILD :
+            kindString = "CLEAN";
+            break;
+        case IncrementalProjectBuilder.INCREMENTAL_BUILD :
+            kindString = "INCREMENTAL";
+            break;
+        default :
+            kindString = String.valueOf(kind);
+            break;
+        }
 
         StringBuilder top = new StringBuilder();
         try (Formatter topper = new Formatter(top)) {
             if (files > 0)
-                topper.format("BUILD %s %s %d file%s built", kind, name, files, files > 1 ? "s were" : " was");
+                topper.format("BUILD %s %s %d file%s built", kindString, name, files, files > 1 ? "s were" : " was");
             else
-                topper.format("BUILD %s %s no build", kind, name);
+                topper.format("BUILD %s %s no build", kindString, name);
         }
 
         return top.append('\n').append(sb).toString();

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerCompilationParticipant.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerCompilationParticipant.java
@@ -1,0 +1,33 @@
+package org.bndtools.builder.classpath;
+
+import org.bndtools.api.ILogger;
+import org.bndtools.api.Logger;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.IClasspathContainer;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.compiler.CompilationParticipant;
+
+public class BndContainerCompilationParticipant extends CompilationParticipant {
+    private static final ILogger logger = Logger.getLogger(BndContainerCompilationParticipant.class);
+
+    public BndContainerCompilationParticipant() {
+        super();
+    }
+
+    @Override
+    public int aboutToBuild(IJavaProject javaProject) {
+        IClasspathContainer oldContainer = BndContainerInitializer.getClasspathContainer(javaProject);
+        try {
+            BndContainerInitializer.requestClasspathContainerUpdate(javaProject);
+        } catch (CoreException e) {
+            logger.logWarning(String.format("Failed to update classpath container for project %s", javaProject.getProject().getName()), e);
+        }
+
+        return BndContainerInitializer.getClasspathContainer(javaProject) != oldContainer ? NEEDS_FULL_BUILD : READY_FOR_BUILD;
+    }
+
+    @Override
+    public boolean isActive(IJavaProject javaProject) {
+        return BndContainerInitializer.getClasspathContainer(javaProject) != null;
+    }
+}

--- a/org.bndtools.templating.gitrepo/bnd.bnd
+++ b/org.bndtools.templating.gitrepo/bnd.bnd
@@ -4,7 +4,7 @@
 	${bndlib},\
 	bndtools.api; version=latest,\
 	org.bndtools.templating; version=latest,\
-	bndtools.utils; version=latest; packages=*,\
+	bndtools.utils; version=project; packages=*,\
 	org.eclipse.jgit; version=3.4.2,\
 	javaewah; version=0.7.9,\
 	com.jcraft.jsch; version=0.1.51,\

--- a/org.bndtools.templating/bnd.bnd
+++ b/org.bndtools.templating/bnd.bnd
@@ -16,7 +16,7 @@
 	slf4j.api,\
 	slf4j.simple,\
 	${junit},\
-	bndtools.utils; packages=*
+	bndtools.utils;version=project;packages=*
 
 
 -privatepackage: org.bndtools.templating.*


### PR DESCRIPTION
This is a big performance win since we now update the bnd classpath
container before the java builder runs which means the java code is not
compiled with an invalid class path and thus needs to be rebuilt after
we update the classpath in the bnd builder.

We use a CompilationParticipant to get "in front of" the java builder
and update the bnd classpath container if necessary before the java
builder runs. This allows the jars built by dependency projects to be
immediately available to dependent project's java builder.