### PR TITLE
Move OSGi standard interfaces ahead of bndlib

### DIFF
--- a/bndtools.core/bnd.bnd
+++ b/bndtools.core/bnd.bnd
@@ -87,11 +87,11 @@ eclipse.deps: \
 
 -buildpath: \
 	osgi.annotation;version=${osgi.annotation.version},\
+	osgi.core;version=${osgi.core.version},\
+	osgi.cmpn;version=${osgi.cmpn.version},\
 	${bndlib},\
 	${aQute-repository};packages=*,\
 	${aQute-resolve},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
 	${eclipse.deps},\
 	javax.xml,\
 	javax.xml.stream,\

--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -1,6 +1,8 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
+	osgi.core;version=${osgi.core.version},\
+	osgi.cmpn;version=${osgi.core.version},\
 	${bndlib},\
 	bndtools.api;version=latest,\
 	bndtools.core;version=latest,\
@@ -20,9 +22,7 @@
 	org.eclipse.m2e.core,\
 	org.eclipse.m2e.jdt,\
 	org.eclipse.osgi,\
-	org.sonatype.plexus:plexus-build-api,\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.core.version}
+	org.sonatype.plexus:plexus-build-api
 
 Bundle-SymbolicName: bndtools.m2e; singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/org.bndtools.headless.build.plugin.ant/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.ant/bnd.bnd
@@ -2,12 +2,12 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
+	osgi.core;version=${osgi.core.version},\
+	osgi.cmpn;version=${osgi.cmpn.version},\
 	${bndlib},\
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
-	bndtools.utils;version=project;packages=*,\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version}
+	bndtools.utils;version=project;packages=*
 
 -testpath: \
 	${junit}

--- a/org.bndtools.headless.build.plugin.gradle/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.gradle/bnd.bnd
@@ -2,13 +2,13 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
+	osgi.core;version=${osgi.core.version},\
+	osgi.cmpn;version=${osgi.cmpn.version},\
 	${bndlib},\
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
 	org.bndtools.versioncontrol.ignores.manager;version=latest,\
 	bndtools.utils;version=project;packages=*,\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
 	${junit}
 -includeresource: \
 	templates=resources/templates/unprocessed, \

--- a/org.bndtools.templating.gitrepo/bnd.bnd
+++ b/org.bndtools.templating.gitrepo/bnd.bnd
@@ -1,6 +1,8 @@
 # This bundle separated from core as it has a dependency on JGit.
 
 -buildpath: \
+	osgi.core;version=${osgi.core.version},\
+	osgi.cmpn;version=${osgi.cmpn.version},\
 	${bndlib},\
 	bndtools.api; version=latest,\
 	org.bndtools.templating; version=latest,\
@@ -8,8 +10,6 @@
 	org.eclipse.jgit; version=3.4.2,\
 	javaewah; version=0.7.9,\
 	com.jcraft.jsch; version=0.1.51,\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
 	org.eclipse.jface,\
 	org.eclipse.ui.workbench,\
 	org.eclipse.swt.cocoa.macosx.x86_64; packages=*,\

--- a/org.bndtools.templating/bnd.bnd
+++ b/org.bndtools.templating/bnd.bnd
@@ -3,10 +3,10 @@
 
 -buildpath:\
 	osgi.annotation;version=${osgi.annotation.version},\
-	${bndlib},\
-	${aQute-repository},\
 	osgi.core; version=${osgi.core.version},\
 	osgi.cmpn; version=${osgi.cmpn.version},\
+	${bndlib},\
+	${aQute-repository},\
 	org.eclipse.equinox.common,\
 	org.antlr:ST4:jar:complete,\
 	com.github.spullara.mustache.java:compiler,\


### PR DESCRIPTION
This avoids picking up higher version annotations than intended, including the R7 meta annotated Component which forces a DS 1.4 requirement

Signed-off-by: Tim Ward <timothyjward@apache.org>