### PR TITLE
builder: Request classpath container update when bnd file modified 

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/DeltaWrapper.java
+++ b/bndtools.builder/src/org/bndtools/builder/DeltaWrapper.java
@@ -134,11 +134,7 @@ class DeltaWrapper {
         if (has(processor.getPropertiesFile()))
             return true;
 
-        List<File> included = processor.getIncluded();
-        if (included == null)
-            return false;
-
-        for (File incl : included) {
+        for (File incl : processor.getIncluded()) {
             if (has(incl))
                 return true;
         }
@@ -200,8 +196,7 @@ class DeltaWrapper {
     }
 
     /**
-     * Check if the target JARs have gone. We look for the buildfiles and the listed jars. If anything is odd, we
-     * rebuild.
+     * Check if the target JARs have gone. We look for the buildfiles and the listed jars. If anything is odd, we rebuild.
      */
     public boolean hasNoTarget(Project model) throws Exception {
 

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerCompilationParticipant.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerCompilationParticipant.java
@@ -3,7 +3,6 @@ package org.bndtools.builder.classpath;
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.compiler.CompilationParticipant;
 
@@ -16,14 +15,12 @@ public class BndContainerCompilationParticipant extends CompilationParticipant {
 
     @Override
     public int aboutToBuild(IJavaProject javaProject) {
-        IClasspathContainer oldContainer = BndContainerInitializer.getClasspathContainer(javaProject);
         try {
-            BndContainerInitializer.requestClasspathContainerUpdate(javaProject);
+            return BndContainerInitializer.requestClasspathContainerUpdate(javaProject) ? NEEDS_FULL_BUILD : READY_FOR_BUILD;
         } catch (CoreException e) {
             logger.logWarning(String.format("Failed to update classpath container for project %s", javaProject.getProject().getName()), e);
         }
-
-        return BndContainerInitializer.getClasspathContainer(javaProject) != oldContainer ? NEEDS_FULL_BUILD : READY_FOR_BUILD;
+        return READY_FOR_BUILD;
     }
 
     @Override

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -32,7 +32,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.IJavaProject;
@@ -589,7 +588,7 @@ public class Central implements IStartupParticipant {
      *             If the callable throws an exception.
      */
     public static <V> V bndCall(Callable<V> callable) throws Exception {
-        return bndCall(callable, new NullProgressMonitor());
+        return bndCall(callable, null);
     }
 
     /**
@@ -613,7 +612,7 @@ public class Central implements IStartupParticipant {
         try {
             long progress = bndLockProgress.get();
             for (int i = 0; i < 120; i++) {
-                if (monitor.isCanceled()) {
+                if ((monitor != null) && monitor.isCanceled()) {
                     throw new CancellationException("Cancelled waiting to acquire bndLock; has waiters: " + bndLock.getQueueLength());
                 }
                 boolean locked = false;


### PR DESCRIPTION
When the bnd file was modified, the JDT builder had nothing to do and then the BndtoolsBuilder noticed the bnd file and rebuilt the bundle. But unless the JDT builder ran, it would not call the compiler participant which would update the classpath container.

So now the BndtoolsBuilder will update the classpath container when it detects a bnd file change. This can then force the JDT builder to rebuild the source with the updated classpath container.

This is a bit like it was before in that it takes 2 passes through the builders for the change to be fully processed. :-(