### PR TITLE
Handle potential timing issue in RepositorySelectionPart

### DIFF
--- a/bndtools.core/src/bndtools/editor/project/RepositorySelectionPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RepositorySelectionPart.java
@@ -104,7 +104,7 @@ public class RepositorySelectionPart extends BndEditorPart implements IResourceC
     private final UpDownButtonBarPart upDownReposPart;
     private RepositoriesEditModel repositories;
     private AddRemoveButtonBarPart addRemove;
-    private Set<IFile> workspaceIndexFiles;
+    private Set<IFile> workspaceIndexFiles = Collections.emptySet();
 
     /**
      * Create the SectionPart.
@@ -440,7 +440,7 @@ public class RepositorySelectionPart extends BndEditorPart implements IResourceC
         repositories = new RepositoriesEditModel(model);
         boolean standalone = repositories.isStandalone();
         btnStandaloneCheckbox.setSelection(standalone);
-        workspaceIndexFiles = standalone ? getWorkspaceIndexFiles() : Collections.<IFile> emptySet();
+        workspaceIndexFiles = standalone ? getWorkspaceIndexFiles() : Collections.emptySet();
         updateButtons();
         reloadRepos();
     }


### PR DESCRIPTION
When creating a RepositorySelectionPart, it is possible that
IResourceChangeListener.resourceChanged could be called before
BndEditorPart.refreshFromModel, causing the former to throw an NPE.
Initialize the workspaceIndexFiles field to the empty set to prevent
this.

Fixes #1812

Signed-off-by: Sean Bright <sean.bright@gmail.com>