### PR TITLE
Fix a few minor problems during release

### DIFF
--- a/bndtools.release/src/bndtools/release/ReleaseHelper.java
+++ b/bndtools.release/src/bndtools/release/ReleaseHelper.java
@@ -193,6 +193,9 @@ public class ReleaseHelper {
         IProject proj = ReleaseUtils.getProject(context.getProject());
         proj.refreshLocal(IResource.DEPTH_INFINITE, context.getProgressMonitor());
 
+        context.getProject()
+            .clear();
+
         return true;
     }
 

--- a/bndtools.release/src/bndtools/release/ReleaseHelper.java
+++ b/bndtools.release/src/bndtools/release/ReleaseHelper.java
@@ -61,7 +61,8 @@ public class ReleaseHelper {
     public final static Pattern VERSION_WITH_MACRO = Pattern.compile(VERSION_WITH_MACRO_STRING);
 
     public static void updateProject(ReleaseContext context) throws Exception {
-        try (ProjectBuilder pb = context.getProject().getBuilder(null)) {
+        try (ProjectBuilder pb = context.getProject()
+            .getBuilder(null)) {
             for (Builder builder : pb.getSubBuilders()) {
 
                 Baseline current = getBaselineForBuilder(builder, context);
@@ -69,7 +70,8 @@ public class ReleaseHelper {
                     continue;
                 }
                 for (Info info : current.getPackageInfos()) {
-                    context.getProject().setPackageInfo(info.packageName, info.suggestedVersion);
+                    context.getProject()
+                        .setPackageInfo(info.packageName, info.suggestedVersion);
                 }
 
                 updateBundleVersion(context, current, builder);
@@ -85,8 +87,10 @@ public class ReleaseHelper {
             File file = builder.getPropertiesFile();
             Properties properties = builder.getProperties();
             if (file == null) {
-                file = context.getProject().getPropertiesFile();
-                properties = context.getProject().getProperties();
+                file = context.getProject()
+                    .getPropertiesFile();
+                properties = context.getProject()
+                    .getProperties();
             }
             final IFile resource = (IFile) ReleaseUtils.toResource(file);
 
@@ -129,7 +133,8 @@ public class ReleaseHelper {
                 }
             };
             if (Display.getCurrent() == null) {
-                Display.getDefault().syncExec(run);
+                Display.getDefault()
+                    .syncExec(run);
             } else
                 run.run();
         }
@@ -138,7 +143,8 @@ public class ReleaseHelper {
     private static Baseline getBaselineForBuilder(Builder builder, ReleaseContext context) {
         Baseline current = null;
         for (Baseline jd : context.getBaselines()) {
-            if (jd.getBsn().equals(builder.getBsn())) {
+            if (jd.getBsn()
+                .equals(builder.getBsn())) {
                 current = jd;
                 break;
             }
@@ -153,21 +159,21 @@ public class ReleaseHelper {
         List<IReleaseParticipant> participants = Activator.getReleaseParticipants();
 
         switch (context.getReleaseOption()) {
-        case UPDATE :
-        default :
-            if (!doUpdateVersions(context, participants)) {
-                return false;
-            }
-            break;
-        case RELEASE :
-            ret = doRelease(context, diffs, participants);
-            break;
-        case UPDATE_RELEASE :
-            if (!doUpdateVersions(context, participants)) {
-                return false;
-            }
-            ret = doRelease(context, diffs, participants);
-            break;
+            case UPDATE :
+            default :
+                if (!doUpdateVersions(context, participants)) {
+                    return false;
+                }
+                break;
+            case RELEASE :
+                ret = doRelease(context, diffs, participants);
+                break;
+            case UPDATE_RELEASE :
+                if (!doUpdateVersions(context, participants)) {
+                    return false;
+                }
+                ret = doRelease(context, diffs, participants);
+                break;
         }
 
         postRelease(context, participants, ret);
@@ -198,13 +204,15 @@ public class ReleaseHelper {
             return false;
         }
 
-        try (ProjectBuilder pb = context.getProject().getBuilder(null)) {
+        try (ProjectBuilder pb = context.getProject()
+            .getBuilder(null)) {
             List<Builder> builders = pb.getSubBuilders();
 
             for (Baseline diff : diffs) {
                 Builder builder = null;
                 for (Builder b : builders) {
-                    if (b.getBsn().equals(diff.getBsn())) {
+                    if (b.getBsn()
+                        .equals(diff.getBsn())) {
                         builder = b;
                         break;
                     }
@@ -227,33 +235,41 @@ public class ReleaseHelper {
             version = ReleaseUtils.getBundleVersion(jar);
         }
         for (String message : reporter.getErrors()) {
-            context.getErrorHandler().error(symbName, version, message);
+            context.getErrorHandler()
+                .error(symbName, version, message);
         }
     }
 
     private static void handleReleaseErrors(ReleaseContext context, Reporter reporter, String symbolicName, String version) {
         for (String message : reporter.getErrors()) {
-            context.getErrorHandler().error(symbolicName, version, message);
+            context.getErrorHandler()
+                .error(symbolicName, version, message);
         }
     }
 
     private static void displayErrors(ReleaseContext context) {
 
-        final String name = context.getProject().getName();
-        final List<Error> errors = new ArrayList<>(context.getErrorHandler().getErrors());
-        context.getErrorHandler().clear();
+        final String name = context.getProject()
+            .getName();
+        final List<Error> errors = new ArrayList<>(context.getErrorHandler()
+            .getErrors());
+        context.getErrorHandler()
+            .clear();
         if (errors.size() > 0) {
             Runnable runnable = new Runnable() {
                 @Override
                 public void run() {
-                    Shell shell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
+                    Shell shell = PlatformUI.getWorkbench()
+                        .getDisplay()
+                        .getActiveShell();
                     ErrorDialog error = new ErrorDialog(shell, name, errors);
                     error.open();
                 }
             };
 
             if (Display.getCurrent() == null) {
-                Display.getDefault().asyncExec(runnable);
+                Display.getDefault()
+                    .asyncExec(runnable);
             } else {
                 runnable.run();
             }
@@ -270,7 +286,8 @@ public class ReleaseHelper {
                 jar = builder.build();
             } else {
                 // No need to rebuild if release only
-                File jarFile = new File(context.getProject().getTarget(), builder.getBsn() + ".jar");
+                File jarFile = new File(context.getProject()
+                    .getTarget(), builder.getBsn() + ".jar");
                 if (jarFile.isFile()) {
                     jar = new Jar(jarFile);
                 } else {
@@ -291,17 +308,22 @@ public class ReleaseHelper {
             }
 
             try (JarResource jr = new JarResource(jar); InputStream is = new BufferedInputStream(jr.openInputStream())) {
-                context.getProject().release(context.getReleaseRepository().getName(), jar.getName(), is);
+                context.getProject()
+                    .release(context.getReleaseRepository()
+                        .getName(), jar.getName(), is);
 
-                if (!context.getProject().isOk()) {
+                if (!context.getProject()
+                    .isOk()) {
                     handleBuildErrors(context, context.getProject(), jar);
                     displayErrors(context);
-                    context.getProject().clear();
+                    context.getProject()
+                        .clear();
                     return false;
                 }
             }
 
-            File file = context.getReleaseRepository().get(symbName, Version.parseVersion(version), null);
+            File file = context.getReleaseRepository()
+                .get(symbName, Version.parseVersion(version), null);
             Jar releasedJar = null;
             if (file != null && file.exists()) {
                 IResource resource = ReleaseUtils.toResource(file);
@@ -399,7 +421,8 @@ public class ReleaseHelper {
         List<RepositoryPlugin> repos = project.getPlugins(RepositoryPlugin.class);
         for (RepositoryPlugin r : repos) {
             if (r.canWrite()) {
-                if (repoName == null || r.getName().equals(repoName)) {
+                if (repoName == null || r.getName()
+                    .equals(repoName)) {
                     repo = r;
                     break;
                 }
@@ -434,7 +457,8 @@ public class ReleaseHelper {
                 if (ReleaseUtils.needsRelease(baseline)) {
                     projectDiff.setRelease(true);
                     projectDiff.setReleaseRequired(true);
-                    if (!baseline.getNewerVersion().equals(baseline.getSuggestedVersion())) {
+                    if (!baseline.getNewerVersion()
+                        .equals(baseline.getSuggestedVersion())) {
                         projectDiff.setVersionUpdateRequired(true);
                         continue;
                     }
@@ -468,7 +492,8 @@ public class ReleaseHelper {
             if (createIfAbsent)
                 file.create(inputStream, false, null);
             else
-                throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, 0, String.format(Messages.fileDoesNotExist, file.getFullPath().toString()), null));
+                throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, 0, String.format(Messages.fileDoesNotExist, file.getFullPath()
+                    .toString()), null));
         }
     }
 
@@ -494,7 +519,8 @@ public class ReleaseHelper {
             if (diff.isRelease()) {
                 for (Baseline baseline : diff.getBaselines()) {
                     try {
-                        Builder builder = diff.getProject().getSubBuilder(baseline.getBsn());
+                        Builder builder = diff.getProject()
+                            .getSubBuilder(baseline.getBsn());
                         String bundleVersion = builder.getUnprocessedProperty(Constants.BUNDLE_VERSION, "");
                         if (bundleVersion.startsWith("${")) {
                             MacroInfo info = new MacroInfo();

--- a/bndtools.release/src/bndtools/release/ReleaseJob.java
+++ b/bndtools.release/src/bndtools/release/ReleaseJob.java
@@ -26,72 +26,79 @@ import bndtools.release.api.ReleaseOption;
 import bndtools.release.api.ReleaseUtils;
 import bndtools.release.nl.Messages;
 
-public class ReleaseJob  extends Job {
+public class ReleaseJob extends Job {
 
-	private ReleaseContext context;
-	private boolean showMessage;
+    private final ReleaseContext context;
+    private final boolean showMessage;
 
-	public ReleaseJob(ReleaseContext context, boolean showMessage) {
-		super(Messages.bundleReleaseJob);
-		this.context = context;
-		this.showMessage = showMessage;
-	}
+    public ReleaseJob(ReleaseContext context, boolean showMessage) {
+        super(Messages.bundleReleaseJob);
+        this.context = context;
+        this.showMessage = showMessage;
+    }
 
-	@Override
-	protected IStatus run(IProgressMonitor monitor) {
+    @Override
+    protected IStatus run(IProgressMonitor monitor) {
 
-		try {
+        try {
 
-			context.setProgressMonitor(monitor);
+            context.setProgressMonitor(monitor);
 
-			IProject proj = ReleaseUtils.getProject(context.getProject());
-			proj.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+            IProject proj = ReleaseUtils.getProject(context.getProject());
+            proj.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 
-			boolean ok = ReleaseHelper.release(context, context.getBaselines());
+            boolean ok = ReleaseHelper.release(context, context.getBaselines());
 
-			ResourcesPlugin.getWorkspace().getRoot().getProject(context.getProject().getName()).refreshLocal(IResource.DEPTH_INFINITE, context.getProgressMonitor());
+            ResourcesPlugin.getWorkspace()
+                .getRoot()
+                .getProject(context.getProject()
+                    .getName())
+                .refreshLocal(IResource.DEPTH_INFINITE, context.getProgressMonitor());
 
-			if (context.getReleaseRepository() != null) {
-				File f = Activator.getLocalRepoLocation(context.getReleaseRepository());
-				if (f != null && f.exists()) {
-					Activator.refreshFile(f);
-				}
-			}
-			if (ok) {
-				StringBuilder sb = new StringBuilder();
-				sb.append(Messages.project2);
-				sb.append(" : "); //$NON-NLS-1$
-				sb.append(context.getProject().getName());
-				sb.append("\n\n"); //$NON-NLS-1$
-				if (context.getReleaseOption() == ReleaseOption.UPDATE) {
-					sb.append(Messages.updatedVersionInfo);
-				} else {
-					sb.append(Messages.released);
-					sb.append(" :\n"); //$NON-NLS-1$
-				}
+            if (context.getReleaseRepository() != null) {
+                File f = Activator.getLocalRepoLocation(context.getReleaseRepository());
+                if (f != null && f.exists()) {
+                    Activator.refreshFile(f);
+                }
+            }
+            if (ok) {
+                StringBuilder sb = new StringBuilder();
+                sb.append(Messages.project2);
+                sb.append(" : "); //$NON-NLS-1$
+                sb.append(context.getProject()
+                    .getName());
+                sb.append("\n\n"); //$NON-NLS-1$
+                if (context.getReleaseOption() == ReleaseOption.UPDATE) {
+                    sb.append(Messages.updatedVersionInfo);
+                } else {
+                    sb.append(Messages.released);
+                    sb.append(" :\n"); //$NON-NLS-1$
+                }
 
-				for (Jar jar : context.getReleasedJars()) {
-					sb.append(ReleaseUtils.getBundleSymbolicName(jar) + "-" + ReleaseUtils.getBundleVersion(jar) + "\n"); //$NON-NLS-1$//$NON-NLS-2$
-				}
+                for (Jar jar : context.getReleasedJars()) {
+                    sb.append(ReleaseUtils.getBundleSymbolicName(jar) + "-" + ReleaseUtils.getBundleVersion(jar) + "\n"); //$NON-NLS-1$//$NON-NLS-2$
+                }
 
-				if (context.getReleaseOption() != ReleaseOption.UPDATE) {
-					sb.append("\n\n"); //$NON-NLS-1$
-					sb.append(Messages.releasedTo);
-					sb.append(" : "); //$NON-NLS-1$
-					sb.append(context.getReleaseRepository().getName());
-				}
-				if (showMessage) {
-					Activator.message(sb.toString());
-				}
-			}
+                if (context.getReleaseOption() != ReleaseOption.UPDATE) {
+                    sb.append("\n\n"); //$NON-NLS-1$
+                    sb.append(Messages.releasedTo);
+                    sb.append(" : "); //$NON-NLS-1$
+                    sb.append(context.getReleaseRepository()
+                        .getName());
+                }
+                if (showMessage) {
+                    Activator.message(sb.toString());
+                }
+            }
 
-		} catch (Exception e) {
-//			for (Baseline spec : context.getBaselines()) {
-//				context.getErrorHandler().error(spec.getBsn(), jarDiff.getSuggestedVersion() != null ? jarDiff.getSuggestedVersion().toString() : "0.0.0", e.getMessage());
-//			}
-			return new Status(Status.ERROR, Activator.PLUGIN_ID, e.getMessage(), e);
-		}
+        } catch (Exception e) {
+            // for (Baseline spec : context.getBaselines()) {
+            // context.getErrorHandler().error(spec.getBsn(), jarDiff.getSuggestedVersion() != null ?
+            // jarDiff.getSuggestedVersion().toString() : "0.0.0", e.getMessage());
+            // }
+            return new Status(Status.ERROR, Activator.PLUGIN_ID, e.getMessage(), e);
+        }
 
-		return Status.OK_STATUS;
-	}
+        return Status.OK_STATUS;
+    }
 }

--- a/bndtools.release/src/bndtools/release/ReleaseJob.java
+++ b/bndtools.release/src/bndtools/release/ReleaseJob.java
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 
-import aQute.bnd.osgi.Jar;
 import bndtools.release.api.ReleaseContext;
 import bndtools.release.api.ReleaseOption;
 import bndtools.release.api.ReleaseUtils;
@@ -47,7 +46,7 @@ public class ReleaseJob extends Job {
             IProject proj = ReleaseUtils.getProject(context.getProject());
             proj.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 
-            boolean ok = ReleaseHelper.release(context, context.getBaselines());
+            boolean success = ReleaseHelper.release(context, context.getBaselines());
 
             ResourcesPlugin.getWorkspace()
                 .getRoot()
@@ -61,7 +60,7 @@ public class ReleaseJob extends Job {
                     Activator.refreshFile(f);
                 }
             }
-            if (ok) {
+            if (success && showMessage) {
                 StringBuilder sb = new StringBuilder();
                 sb.append(Messages.project2);
                 sb.append(" : "); //$NON-NLS-1$
@@ -75,8 +74,9 @@ public class ReleaseJob extends Job {
                     sb.append(" :\n"); //$NON-NLS-1$
                 }
 
-                for (Jar jar : context.getReleasedJars()) {
-                    sb.append(ReleaseUtils.getBundleSymbolicName(jar) + "-" + ReleaseUtils.getBundleVersion(jar) + "\n"); //$NON-NLS-1$//$NON-NLS-2$
+                for (String jarInfo : context.getReleaseSummaries()) {
+                    sb.append(jarInfo)
+                        .append('\n');
                 }
 
                 if (context.getReleaseOption() != ReleaseOption.UPDATE) {
@@ -86,9 +86,8 @@ public class ReleaseJob extends Job {
                     sb.append(context.getReleaseRepository()
                         .getName());
                 }
-                if (showMessage) {
-                    Activator.message(sb.toString());
-                }
+
+                Activator.message(sb.toString());
             }
 
         } catch (Exception e) {

--- a/bndtools.release/src/bndtools/release/api/ReleaseContext.java
+++ b/bndtools.release/src/bndtools/release/api/ReleaseContext.java
@@ -32,7 +32,7 @@ public class ReleaseContext {
     private IProgressMonitor progressMonitor;
 
     private final List<Jar> releasedJars;
-    private final Map<String,Object> properties;
+    private final Map<String, Object> properties;
     private final ErrorHandler errorHandler;
     private Scope currentScope;
     private ReleaseOption releaseOption;
@@ -44,7 +44,7 @@ public class ReleaseContext {
         this.releaseOption = releaseOption;
 
         this.releasedJars = new ArrayList<Jar>();
-        this.properties = new HashMap<String,Object>();
+        this.properties = new HashMap<String, Object>();
         this.errorHandler = new ErrorHandler();
     }
 
@@ -95,7 +95,7 @@ public class ReleaseContext {
         return properties.get(name);
     }
 
-    public Map<String,Object> getPropertyMap() {
+    public Map<String, Object> getPropertyMap() {
         return properties;
     }
 
@@ -163,8 +163,7 @@ public class ReleaseContext {
 
     /**
      * @deprecated Use setReleaseOption instead
-     * @param updateOnly
-     *            true to indicate 'update only mode'
+     * @param updateOnly true to indicate 'update only mode'
      */
     @Deprecated
     public void setUpdateOnly(boolean updateOnly) {

--- a/bndtools.release/src/bndtools/release/api/ReleaseContext.java
+++ b/bndtools.release/src/bndtools/release/api/ReleaseContext.java
@@ -92,11 +92,7 @@ public class ReleaseContext {
     }
 
     public void close() {
-        // XXX: This code doesn't do anything, these JARs were closed by
-        // ProjectBuilder
-        for (Jar jar : releasedJars) {
-            jar.close();
-        }
+        // the released jars were closed by the project builder
     }
 
     public void setProperty(String name, Object value) {

--- a/bndtools.release/src/bndtools/release/api/ReleaseContext.java
+++ b/bndtools.release/src/bndtools/release/api/ReleaseContext.java
@@ -32,6 +32,7 @@ public class ReleaseContext {
     private IProgressMonitor progressMonitor;
 
     private final List<Jar> releasedJars;
+    private final List<String> releasedJarSummaries;
     private final Map<String, Object> properties;
     private final ErrorHandler errorHandler;
     private Scope currentScope;
@@ -44,6 +45,7 @@ public class ReleaseContext {
         this.releaseOption = releaseOption;
 
         this.releasedJars = new ArrayList<Jar>();
+        this.releasedJarSummaries = new ArrayList<String>();
         this.properties = new HashMap<String, Object>();
         this.errorHandler = new ErrorHandler();
     }
@@ -75,13 +77,23 @@ public class ReleaseContext {
 
     public void addReleasedJar(Jar jar) {
         releasedJars.add(jar);
+
+        // Save off our summary info now, because our JARs will get
+        // closed out from underneath us later
+        releasedJarSummaries.add(ReleaseUtils.getBundleSymbolicName(jar) + "-" + ReleaseUtils.getBundleVersion(jar));
     }
 
     public List<Jar> getReleasedJars() {
         return releasedJars;
     }
 
+    public List<String> getReleaseSummaries() {
+        return releasedJarSummaries;
+    }
+
     public void close() {
+        // XXX: This code doesn't do anything, these JARs were closed by
+        // ProjectBuilder
         for (Jar jar : releasedJars) {
             jar.close();
         }


### PR DESCRIPTION
Two problems are resolved by this changeset:

1. When ProjectBuilder goes out of scope it closes all of the JARs in its close list and classpath. When we try to iterate those and get metadata, we get an exception because the JARs are already closed. Instead grab the metadata earlier and save it for later.
2. If a baselining error was present before an 'Update and Release' (i.e. "The bundle version (X.X.X/X.X.X) is too low...") we would throw up a dialog indicating that there was an error during the release when there was none. Instead we now clear the error list after the version update.