### PR TITLE
central: Map file to shortest path when multiple paths are present

### DIFF
--- a/bndtools.utils/src/org/bndtools/utils/workspace/FileUtils.java
+++ b/bndtools.utils/src/org/bndtools/utils/workspace/FileUtils.java
@@ -7,7 +7,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-
+import java.util.Arrays;
 import org.bndtools.utils.osgi.BundleUtils;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -128,8 +128,14 @@ public class FileUtils {
     }
 
     public static IFile[] getWorkspaceFiles(File javaFile) {
-        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        return root.findFilesForLocationURI(javaFile.toURI());
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace()
+            .getRoot();
+        IFile[] candidates = root.findFilesForLocationURI(javaFile.toURI());
+        Arrays.sort(candidates, (a, b) -> Integer.compare(a.getFullPath()
+            .segmentCount(),
+            b.getFullPath()
+                .segmentCount()));
+        return candidates;
     }
 
     public static File toFile(IWorkspaceRoot root, IPath path) {


### PR DESCRIPTION
If the Eclipse workspace is constructed where the same file on the file
system is mapped into multiple Eclipse projects, we need to select one
of the resources. There is no way to know the proper answer, but we
choose the resource whose IPath has the smallest segment count. When
mapping the IPath to an IProject, this will return the project "closest"
to the resource.

Fixes https://github.com/bndtools/bndtools/issues/1847
