### PR TITLE
core: Added quick fixes for missing bundles (implements #1589)

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -209,6 +209,21 @@
 				</with>
 			</enablement>
 		</quickFixProcessor>
+		<quickFixProcessor id="ImportPackageQuickFixProcessor"
+			name="Import Package Quick Fix" requiredSourceLevel="1.5"
+			class="org.bndtools.core.editors.ImportPackageQuickFixProcessor"
+			icon="icons/bricks.png">
+ 			<handledMarkerTypes>
+				<markerType id="org.eclipse.jdt.core.problem" />
+			</handledMarkerTypes>
+			<enablement>
+				<with variable="projectNatures">
+					<iterate operator="or">
+						<equals value="bndtools.core.bndnature" />
+					</iterate>
+				</with>
+			</enablement>
+		</quickFixProcessor>
 	</extension>
 
    <extension

--- a/bndtools.core/bnd.bnd
+++ b/bndtools.core/bnd.bnd
@@ -106,4 +106,7 @@ eclipse.deps: \
 -testpath: \
 	slf4j.api,\
 	slf4j.simple,\
+	org.assertj.core,\
+	org.mockito.mockito-core,\
+	org.objenesis,\
 	${junit}

--- a/bndtools.core/src/org/bndtools/core/editors/ImportPackageQuickFixProcessor.java
+++ b/bndtools.core/src/org/bndtools/core/editors/ImportPackageQuickFixProcessor.java
@@ -1,0 +1,542 @@
+package org.bndtools.core.editors;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.bndtools.api.BndtoolsConstants;
+import org.bndtools.api.ILogger;
+import org.bndtools.api.Logger;
+import org.bndtools.core.ui.icons.Icons;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceRuleFactory;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NameQualifiedType;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.ui.text.java.IInvocationContext;
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+import org.eclipse.jdt.ui.text.java.IQuickFixProcessor;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+import org.osgi.framework.namespace.BundleNamespace;
+import org.osgi.framework.namespace.IdentityNamespace;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+import org.osgi.service.repository.Repository;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.build.WorkspaceRepository;
+import aQute.bnd.build.model.BndEditModel;
+import aQute.bnd.build.model.clauses.VersionedClause;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.osgi.resource.CapReqBuilder;
+import aQute.bnd.properties.Document;
+import aQute.bnd.properties.IDocument;
+import aQute.bnd.service.RepositoryPlugin;
+import aQute.lib.collections.MultiMap;
+import aQute.lib.io.ByteBufferInputStream;
+import aQute.lib.io.IO;
+import aQute.lib.strings.Strings;
+import bndtools.central.Central;
+import bndtools.central.RepositoryUtils;
+
+public class ImportPackageQuickFixProcessor implements IQuickFixProcessor {
+
+    private static final ILogger logger = Logger.getLogger(ImportPackageQuickFixProcessor.class);
+
+    // Relevance constants
+    public static final int ADD_BUNDLE = 15;
+    public static final int ADD_BUNDLE_WORKSPACE = ADD_BUNDLE + 1;
+
+    @Override
+    public boolean hasCorrections(ICompilationUnit unit, int problemId) {
+
+        switch (problemId) {
+            case IProblem.ImportNotFound :
+            case IProblem.UndefinedType :
+                return true;
+            default :
+                return false;
+        }
+    }
+
+    private static Requirement buildRequirement(String importName) {
+        final CapReqBuilder b = new CapReqBuilder(PackageNamespace.PACKAGE_NAMESPACE);
+        b.addFilter(PackageNamespace.PACKAGE_NAMESPACE, importName, null, new Attrs());
+        return b.buildSyntheticRequirement();
+    }
+
+    private Collection<Capability> searchRepository(Repository osgiRepo, String pkg) {
+        final Requirement req = buildRequirement(pkg);
+        Map<Requirement, Collection<Capability>> providers = osgiRepo.findProviders(Collections.singleton(req));
+        return providers.get(req);
+    }
+
+    static class BndBuildPathHandler {
+        private final IInvocationContext context;
+        private IFile bndFile;
+        private IDocument bndDoc;
+        private BndEditModel bndModel;
+        private List<VersionedClause> buildPath;
+        private Set<String> buildPathBundles;
+        private Set<VersionedClause> buildPathVersioned;
+        private IProgressMonitor monitor;
+
+        public BndBuildPathHandler(IInvocationContext context) {
+            this.context = context;
+        }
+
+        public IProgressMonitor getProgressMonitor() {
+            return monitor;
+        }
+
+        public void setProgressMonitor(IProgressMonitor monitor) {
+            this.monitor = monitor;
+        }
+
+        // This has been pushed into this method to defer initialization as this makes testing easier.
+        void loadFileInfo() {
+            if (bndFile != null) {
+                return;
+            }
+            final ICompilationUnit compUnit = context.getCompilationUnit();
+            final IJavaProject java = compUnit.getJavaProject();
+            final IProject eclipse = java.getProject();
+            bndFile = eclipse.getFile(Project.BNDFILE);
+        }
+
+        Workspace getWorkspace() throws Exception {
+            return Central.getWorkspace();
+        }
+
+        void loadModel() throws CoreException {
+            if (buildPathVersioned != null) {
+                return;
+            }
+            loadFileInfo();
+            String contents;
+            try {
+                contents = IO.collect(new InputStreamReader(bndFile.getContents(), bndFile.getCharset()));
+                bndDoc = new Document(contents);
+                bndModel = new BndEditModel(getWorkspace());
+                bndModel.loadFrom(bndDoc);
+            } catch (IOException e) {
+                throw new CoreException(new Status(IStatus.ERROR, BndtoolsConstants.CORE_PLUGIN_ID, "Error trying to read " + bndFile, e));
+            } catch (Exception e) {
+                throw new CoreException(new Status(IStatus.ERROR, BndtoolsConstants.CORE_PLUGIN_ID, "Error trying to access Bnd workspace", e));
+            }
+
+            final List<VersionedClause> origBuildPath = bndModel.getBuildPath();
+            buildPath = origBuildPath == null ? new ArrayList<>() : new ArrayList<>(origBuildPath);
+            final int capacity = 2 * buildPath.size() + 1;
+            buildPathBundles = new HashSet<>(capacity);
+            buildPathVersioned = new HashSet<>(capacity);
+            for (VersionedClause bundleVersion : buildPath) {
+                buildPathBundles.add(bundleVersion.getName());
+                buildPathVersioned.add(bundleVersion);
+            }
+        }
+
+        public List<VersionedClause> getBuildPath() throws CoreException {
+            loadModel();
+            return buildPath;
+        }
+
+        public IFile getBndFile() {
+            loadFileInfo();
+            return bndFile;
+        }
+
+        public void addBundle(String bundle) throws CoreException {
+            addBundle(new VersionedClause(bundle, new Attrs()));
+        }
+
+        public void addBundle(VersionedClause versionedBundle) throws CoreException {
+            loadModel();
+            buildPathBundles.add(versionedBundle.getName());
+            if (buildPathVersioned.add(versionedBundle)) {
+                buildPath.add(versionedBundle);
+            }
+            bndModel.setBuildPath(buildPath);
+            bndModel.saveChangesTo(bndDoc);
+            InputStream str;
+            try {
+                str = new ByteBufferInputStream(bndDoc.get()
+                    .getBytes(bndFile.getCharset()));
+            } catch (UnsupportedEncodingException e) {
+                throw new CoreException(new Status(IStatus.ERROR, BndtoolsConstants.CORE_PLUGIN_ID, "Invalid encoding for " + bndFile, e));
+            }
+            bndFile.setContents(str, IResource.KEEP_HISTORY, monitor);
+        }
+
+        public boolean containsBundle(String bundle) throws CoreException {
+            loadModel();
+            return buildPathBundles.contains(bundle);
+        }
+    }
+
+    class AddBundleJob extends WorkspaceJob {
+        private final String bundle;
+        private final BndBuildPathHandler handler;
+
+        public AddBundleJob(IInvocationContext context, String bundle) {
+            super("Adding '" + bundle + "' to Bnd build path");
+            this.bundle = bundle;
+            handler = getBuildPathHandler(context);
+            IWorkspace workspace = ResourcesPlugin.getWorkspace();
+            IResourceRuleFactory ruleFactory = workspace.getRuleFactory();
+            setRule(ruleFactory.modifyRule(handler.getBndFile()));
+        }
+
+        @Override
+        public IStatus runInWorkspace(IProgressMonitor monitor) {
+            try {
+                handler.setProgressMonitor(monitor);
+                handler.addBundle(bundle);
+
+                return Status.OK_STATUS;
+            } catch (CoreException e) {
+                return e.getStatus();
+            }
+        }
+    }
+
+    BndBuildPathHandler getBuildPathHandler(IInvocationContext context) {
+        return new BndBuildPathHandler(context);
+    }
+
+    // Lazily initialize this or else it won't load during testing.
+    static Image ICON;
+
+    class AddBundleCompletionProposal implements IJavaCompletionProposal {
+
+        final String bundle;
+        final String displayString;
+        final int relevance;
+        final IInvocationContext context;
+
+        public AddBundleCompletionProposal(String bundle, List<String> r, int relevance, IInvocationContext context) {
+            this.bundle = bundle;
+            this.relevance = relevance;
+            this.context = context;
+            final String firstRepo = r.get(0);
+            switch (r.size()) {
+                case 1 :
+                    this.displayString = Strings.format("Add bundle '%s' to Bnd build path (from %s)", bundle, firstRepo);
+                    break;
+                case 2 :
+                    this.displayString = Strings.format("Add bundle '%s' to Bnd build path (from %s + 1 other)", bundle, firstRepo);
+                    break;
+                default :
+                    this.displayString = Strings.format("Add bundle '%s' to Bnd build path (from %s + %d others)", bundle, firstRepo, r.size() - 1);
+                    break;
+            }
+        }
+
+        @Override
+        public void apply(org.eclipse.jface.text.IDocument document) {
+            AddBundleJob job = new AddBundleJob(context, bundle);
+            job.schedule();
+        }
+
+        /**
+         * @see org.eclipse.jface.text.contentassist.ICompletionProposal#getSelection(org.eclipse.jface.text.IDocument)
+         */
+        @Override
+        public Point getSelection(org.eclipse.jface.text.IDocument document) {
+            return new Point(context.getSelectionOffset(), context.getSelectionLength());
+        }
+
+        @Override
+        public String getAdditionalProposalInfo() {
+            return displayString;
+        }
+
+        @Override
+        public String getDisplayString() {
+            return displayString;
+        }
+
+        @Override
+        public Image getImage() {
+            if (ICON == null) {
+                try {
+                    ICON = Icons.desc("bundle")
+                        .createImage();
+                } catch (RuntimeException e) {
+                    logger.logError("Couldn't load bundle image", e);
+                }
+            }
+            return ICON;
+        }
+
+        @Override
+        public IContextInformation getContextInformation() {
+            return new IContextInformation() {
+
+                @Override
+                public String getContextDisplayString() {
+                    return "Added " + bundle + " to build path";
+                }
+
+                @Override
+                public Image getImage() {
+                    return null;
+                }
+
+                @Override
+                public String getInformationDisplayString() {
+                    return "Added " + bundle + " to build path - info";
+                }
+
+            };
+        }
+
+        @Override
+        public int getRelevance() {
+            return relevance;
+        }
+    }
+
+    // Wrap these methods to make it easier to test.
+    Workspace getWorkspace() throws Exception {
+        return Central.getWorkspace();
+    }
+
+    // Wrap these methods to make it easier to test.
+    Repository getWorkspaceRepo() throws Exception {
+        return Central.getWorkspaceR5Repository();
+    }
+
+    List<RepositoryPlugin> listRepositories() {
+        return RepositoryUtils.listRepositories(true);
+    }
+
+    IJavaCompletionProposal[] getSuggestions(Set<String> pkgs, IInvocationContext context) throws CoreException {
+        List<RepositoryPlugin> ps = listRepositories();
+
+        final BndBuildPathHandler handler = getBuildPathHandler(context);
+        MultiMap<String, String> bundles = new MultiMap<>();
+        String wsName = null;
+        boolean loggedWorkspaceError = false;
+        for (String pkg : pkgs) {
+            for (RepositoryPlugin p : ps) {
+                Collection<Capability> caps = null;
+                if (p instanceof Repository) {
+                    caps = searchRepository((Repository) p, pkg);
+                } else if (p instanceof WorkspaceRepository) {
+                    try {
+                        caps = searchRepository(getWorkspaceRepo(), pkg);
+                        wsName = p.getName();
+                    } catch (Exception e) {
+                        if (!loggedWorkspaceError) {
+                            logger.logError("Error trying to fetch the repository for the current workspace", e);
+                            loggedWorkspaceError = true;
+                        }
+                    }
+                }
+                if (caps == null) {
+                    continue;
+                }
+                for (Capability cap : caps) {
+                    final String bsn = capabilityToBSN(cap);
+                    if (bsn != null && !handler.containsBundle(bsn)) {
+                        bundles.add(bsn, p.getName());
+                    }
+                }
+            }
+        }
+        if (bundles.isEmpty()) {
+            return null;
+        }
+        IJavaCompletionProposal[] retval = new IJavaCompletionProposal[bundles.size()];
+        int i = 0;
+        for (Map.Entry<String, List<String>> bundle : bundles.entrySet()) {
+            // NOTE: The call to contains() here, based on the current MultiMap implementation, will
+            // do a linear search. Because a single bundle is unlikely to be found in more than a few
+            // repos in any given workspace this probably won't make a difference, but if any performance issues show up
+            // in the future this would be a place to look.
+            final int relevance = bundle.getValue()
+                .contains(wsName) ? ADD_BUNDLE_WORKSPACE : ADD_BUNDLE;
+            retval[i++] = new AddBundleCompletionProposal(bundle.getKey(), bundle.getValue(), relevance, context);
+        }
+        return retval;
+    }
+
+    private Name getPackageFromImportNotFound(IInvocationContext context, IProblemLocation location) {
+        ASTNode selectedNode = location.getCoveringNode(context.getASTRoot());
+        if (selectedNode == null) {
+            return null;
+        }
+        ImportDeclaration declaration = (ImportDeclaration) ((selectedNode instanceof ImportDeclaration) ? selectedNode : ASTNodes.getParent(selectedNode, ASTNode.IMPORT_DECLARATION));
+        if (declaration == null) {
+            return null;
+        }
+
+        Name name = declaration.getName();
+
+        if (!name.isQualifiedName()) {
+            if (!declaration.isOnDemand() || declaration.isStatic()) {
+                return null;
+            }
+        } else if (declaration.isStatic()) {
+            final QualifiedName qName = (QualifiedName) name;
+            name = qName.getQualifier();
+            if (declaration.isOnDemand()) {
+                // return name;
+            } else if (name.isQualifiedName()) {
+                name = ((QualifiedName) name).getQualifier();
+            } else {
+                return null;
+            }
+        } else if (!declaration.isOnDemand()) {
+            name = ((QualifiedName) name).getQualifier();
+        }
+
+        return skipClasses(name);
+    }
+
+    // Recurse through the elements of a qualified name from right to left, skipping elements
+    // that start with a capital letter. Eg, "my.pkg.Clazz" would become "my.pkg". This is a heuristic to guess the
+    // package name as opposed to a type name.
+    private Name skipClasses(Name name) {
+        while (name instanceof QualifiedName && Character.isUpperCase(((QualifiedName) name).getName()
+            .getIdentifier()
+            .charAt(0))) {
+            name = ((QualifiedName) name).getQualifier();
+        }
+        return name;
+    }
+
+    private Name getPackageFromUndefinedType(IInvocationContext context, IProblemLocation location) {
+
+        ASTNode selectedNode = location.getCoveringNode(context.getASTRoot());
+        if (selectedNode == null) {
+            return null;
+        }
+        while (selectedNode instanceof Name) {
+            selectedNode = selectedNode.getParent();
+        }
+        Name name = null;
+        if (selectedNode instanceof SimpleType) {
+            name = ((SimpleType) selectedNode).getName();
+            if (!name.isQualifiedName()) {
+                return null;
+            }
+            name = ((QualifiedName) name).getQualifier();
+        } else if (selectedNode instanceof NameQualifiedType) {
+            name = ((NameQualifiedType) selectedNode).getQualifier();
+        }
+
+        if (name == null) {
+            return null;
+        }
+
+        return skipClasses(name);
+    }
+
+    @Override
+    public IJavaCompletionProposal[] getCorrections(IInvocationContext context, IProblemLocation[] locations) throws CoreException {
+        Set<String> pkgs = new HashSet<>(locations.length * 2 + 1);
+
+        for (IProblemLocation location : locations) {
+            Name name;
+            switch (location.getProblemId()) {
+                case IProblem.ImportNotFound :
+                    name = getPackageFromImportNotFound(context, location);
+                    break;
+                case IProblem.UndefinedType :
+                    name = getPackageFromUndefinedType(context, location);
+                    break;
+                default :
+                    continue;
+            }
+
+            if (name == null) {
+                continue;
+            }
+
+            final String pkg = name.getFullyQualifiedName();
+            // Don't suggest adding a bundle to fix missing package in import if current Compilation Unit
+            // is already part of that package.
+            final PackageDeclaration ourPkg = context.getASTRoot()
+                .getPackage();
+            if (ourPkg != null && pkg.equals(ourPkg.getName()
+                .getFullyQualifiedName())) {
+                continue;
+            }
+            pkgs.add(pkg);
+        }
+        if (pkgs.isEmpty()) {
+            return null;
+        }
+        return getSuggestions(pkgs, context);
+    }
+
+    /**
+     * Converts a package capability into a bundle symbolic name.
+     *
+     * @param cap The capability object describing the package being imported.
+     * @return A user-friendly string with the BSN.
+     */
+    public static String capabilityToBSN(Capability cap) {
+        Resource res = cap.getResource();
+        // Guard against badly behaved repos
+        if (res == null) {
+            logger.logWarning("Didn't find bundle name for capability " + cap, null);
+            return null;
+        }
+        List<Capability> caps = cap.getResource()
+            .getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+
+        if (!caps.isEmpty()) {
+            cap = caps.get(0);
+            final Map<String, Object> attributes = cap.getAttributes();
+            Object value = attributes.get(IdentityNamespace.IDENTITY_NAMESPACE);
+            if (value != null) {
+                return value.toString();
+            }
+        }
+        caps = cap.getResource()
+            .getCapabilities(BundleNamespace.BUNDLE_NAMESPACE);
+        if (!caps.isEmpty()) {
+            cap = caps.get(0);
+            final Map<String, Object> attributes = cap.getAttributes();
+            Object value = attributes.get(BundleNamespace.BUNDLE_NAMESPACE);
+            if (value != null) {
+                return value.toString();
+            }
+        }
+        logger.logWarning("Didn't find bundle name for capability " + cap, null);
+        return null;
+    }
+}

--- a/bndtools.core/test/org/bndtools/core/editors/FakeFile.java
+++ b/bndtools.core/test/org/bndtools/core/editors/FakeFile.java
@@ -1,0 +1,242 @@
+package org.bndtools.core.editors;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import aQute.lib.io.ByteBufferOutputStream;
+
+import static org.bndtools.core.editors.ImportPackageQuickFixProcessorTest.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class FakeFile {
+
+    static class FileInfo {
+        private byte[] fContents;
+        private String fCharset;
+
+        public FileInfo(byte[] contents, String charset) {
+            fContents = contents;
+            fCharset = charset;
+        }
+
+        public InputStream getContentStream() throws CoreException {
+            if (!exists()) {
+                throw new CoreException(new Status(IStatus.ERROR, "fakefile", "File does not exist"));
+            }
+            return new ByteArrayInputStream(fContents);
+        }
+
+        public byte[] getRawContents() {
+            return fContents;
+        }
+
+        public String getContents() {
+            try {
+                return new String(fContents, fCharset);
+            } catch (UnsupportedEncodingException e) {
+                fail("Unsupported encoding: " + fCharset, e);
+            }
+            return null;
+
+        }
+
+        public void setContents(byte[] contents) {
+            fContents = contents;
+        }
+
+        public void setContents(String contents) {
+            try {
+                fContents = contents == null ? null : contents.getBytes(fCharset);
+            } catch (UnsupportedEncodingException e) {
+                fail("Unsupported encoding: " + fCharset, e);
+            }
+        }
+
+        public void setContents(InputStream source) throws CoreException {
+            BufferedInputStream buf = new BufferedInputStream(source);
+            try (ByteBufferOutputStream out = new ByteBufferOutputStream(4096)) {
+                int b;
+                while ((b = buf.read()) > -1) {
+                    out.write(b);
+                }
+                setContents(out.toByteArray());
+            } catch (IOException e) {
+                throw new CoreException(new Status(IStatus.ERROR, "fakefile", "Error reading from source", e));
+            }
+        }
+
+        public String getCharset() {
+            return fCharset;
+        }
+
+        public void setCharset(String charset) {
+            fCharset = charset;
+        }
+
+        public boolean exists() {
+            return fContents != null;
+        }
+    }
+
+    protected static Map<IFile, FileInfo> fakeInfo = new WeakHashMap<>();
+
+    public static void setContents(IFile fakeFile, byte[] contents) {
+        FileInfo info = safeGetFileInfo(fakeFile);
+        info.setContents(contents);
+    }
+
+    public static void setContents(IFile fakeFile, String contents) {
+        safeGetFileInfo(fakeFile).setContents(contents);
+    }
+
+    public static byte[] rawContentsOf(IFile fakeFile) {
+        return safeGetFileInfo(fakeFile).getRawContents();
+    }
+
+    public static String contentsOf(IFile fakeFile) {
+        return safeGetFileInfo(fakeFile).getContents();
+    }
+
+    protected static FileInfo safeGetFileInfo(IFile fakeFile) {
+        FileInfo info = fakeInfo.get(fakeFile);
+        if (info == null) {
+            throw new AssertionError("Supplied file is not a faked file");
+        }
+        return info;
+    }
+
+    public static String charsetOf(IFile fakeFile) {
+        return safeGetFileInfo(fakeFile).getCharset();
+    }
+
+    public static IFile fakeFile() {
+        return fakeFile(null);
+    }
+
+    public static IFile fakeFile(final byte[] contents) {
+        return fakeFile(contents, "utf-8");
+    }
+
+    @SuppressWarnings("deprecation")
+    public static IFile fakeFile(final byte[] contents, final String charset) {
+        final IFile retval = mock(IFile.class, DO_NOT_CALL);
+        final FileInfo info = new FileInfo(contents, charset);
+        fakeInfo.put(retval, info);
+
+        try {
+            doAnswer(new Answer<String>() {
+                @Override
+                public String answer(InvocationOnMock invocation) {
+                    return info.getContents();
+                }
+            }).when(retval)
+                .toString();
+
+            doAnswer(new Answer<Boolean>() {
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                    return info.exists();
+                }
+            }).when(retval)
+                .exists();
+
+            doAnswer(new Answer<String>() {
+                @Override
+                public String answer(InvocationOnMock invocation) throws Throwable {
+                    return retval.getCharset(true);
+                }
+            }).when(retval)
+                .getCharset();
+
+            doAnswer(new Answer<String>() {
+                @Override
+                public String answer(InvocationOnMock invocation) throws Throwable {
+                    return info.exists() ? info.getCharset() : null;
+                }
+            }).when(retval)
+                .getCharset(anyBoolean());
+
+            doAnswer(new Answer<InputStream>() {
+                @Override
+                public InputStream answer(InvocationOnMock invocation) throws Throwable {
+                    return info.getContentStream();
+                }
+            }).when(retval)
+                .getContents();
+
+            doAnswer(new Answer<InputStream>() {
+                @Override
+                public InputStream answer(InvocationOnMock invocation) throws Throwable {
+                    return info.getContentStream();
+                }
+            }).when(retval)
+                .getContents(anyBoolean());
+
+            doAnswer(new Answer<Void>() {
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
+                    fail("Shouldn't use deprecated API");
+                    return null;
+                }
+            }).when(retval)
+                .setCharset(any());
+
+            doAnswer(new Answer<Void>() {
+                @Override
+                public Void answer(InvocationOnMock invocation) {
+                    String charset = invocation.getArgumentAt(0, String.class);
+                    info.setCharset(charset);
+                    return null;
+                }
+            }).when(retval)
+                .setCharset(any(), any());
+
+            doAnswer(new Answer<Void>() {
+
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
+                    // public void setContents(InputStream source, int updateFlags, IProgressMonitor monitor) throws
+                    // CoreException {
+                    final InputStream source = invocation.getArgumentAt(0, InputStream.class);
+                    info.setContents(source);
+                    return null;
+                }
+
+            }).when(retval)
+                .setContents(any(InputStream.class), anyInt(), any());
+
+            doAnswer(new Answer<Void>() {
+
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
+                    // public void setContents(InputStream source, boolean force, boolean keepHistory, IProgressMonitor
+                    // monitor) throws CoreException {
+                    final InputStream source = invocation.getArgumentAt(0, InputStream.class);
+                    info.setContents(source);
+                    return null;
+                }
+
+            }).when(retval)
+                .setContents(any(InputStream.class), anyBoolean(), anyBoolean(), any());
+
+        } catch (CoreException e) {
+            fail("Couldn't set up mock", e);
+        }
+
+        return retval;
+    }
+}

--- a/bndtools.core/test/org/bndtools/core/editors/ImportPackageQuickFixProcessorAddBundleCompletionProposalTest.java
+++ b/bndtools.core/test/org/bndtools/core/editors/ImportPackageQuickFixProcessorAddBundleCompletionProposalTest.java
@@ -1,0 +1,54 @@
+package org.bndtools.core.editors;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImportPackageQuickFixProcessorAddBundleCompletionProposalTest {
+
+    private static final String BUNDLE = "my.bundle";
+    private static final String REPO1 = "Repo 1";
+    private static final String REPO2 = "Repo 2";
+    private static final String WORKSPACE = "Workspace Bndtools repo";
+    private static final int RELEVANCE = 2;
+
+    private ImportPackageQuickFixProcessor.AddBundleCompletionProposal sut;
+
+    @Before
+    public void setUp() {
+        setUpWithRepos(REPO1);
+    }
+
+    public void setUpWithRepos(String... repos) {
+        List<String> r = new ArrayList<>(repos.length);
+        for (String repo : repos) {
+            r.add(repo);
+        }
+        sut = new ImportPackageQuickFixProcessor().new AddBundleCompletionProposal(BUNDLE, r, RELEVANCE, null);
+    }
+
+    @Test
+    public void displayString_returnsDescription() {
+        assertThat(sut.getDisplayString()).isEqualTo(String.format("Add bundle '%s' to Bnd build path (from %s)", BUNDLE, REPO1));
+    }
+
+    @Test
+    public void displayString_withTwoRepos_returnsDescription() {
+        setUpWithRepos(REPO2, REPO1);
+        assertThat(sut.getDisplayString()).isEqualTo(String.format("Add bundle '%s' to Bnd build path (from %s + 1 other)", BUNDLE, REPO2));
+    }
+
+    @Test
+    public void displayString_withThreeRepos_returnsDescription() {
+        setUpWithRepos(WORKSPACE, REPO2, REPO1);
+        assertThat(sut.getDisplayString()).isEqualTo(String.format("Add bundle '%s' to Bnd build path (from %s + 2 others)", BUNDLE, WORKSPACE));
+    }
+
+    @Test
+    public void getRelevance_returnsRelevance() {
+        assertThat(sut.getRelevance()).isEqualTo(RELEVANCE);
+    }
+}

--- a/bndtools.core/test/org/bndtools/core/editors/ImportPackageQuickFixProcessorBndBuildPathHandlerTest.java
+++ b/bndtools.core/test/org/bndtools/core/editors/ImportPackageQuickFixProcessorBndBuildPathHandlerTest.java
@@ -1,0 +1,136 @@
+package org.bndtools.core.editors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.namespace.BundleNamespace;
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.build.model.clauses.VersionedClause;
+import aQute.bnd.header.Attrs;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.ui.text.java.IInvocationContext;
+
+import static org.bndtools.core.editors.ImportPackageQuickFixProcessorTest.DO_NOT_CALL;
+
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+import static org.bndtools.core.editors.FakeFile.*;
+
+public class ImportPackageQuickFixProcessorBndBuildPathHandlerTest {
+
+    private ImportPackageQuickFixProcessor.BndBuildPathHandler sut;
+
+    private List<VersionedClause> bundles;
+    private IFile fakeFile;
+
+    @Before
+    public void setUp() {
+        fakeFile = fakeFile();
+        bundles = new ArrayList<>();
+        bundles.add(new VersionedClause("my.test.bundle", new Attrs()));
+        Attrs attrs = new Attrs();
+        attrs.put(BundleNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE, "1.2.3");
+        bundles.add(new VersionedClause("my.second.bundle", attrs));
+        setBuildPath(bundles);
+
+        IProject eclipse = mock(IProject.class, DO_NOT_CALL);
+        doReturn(fakeFile).when(eclipse)
+            .getFile(Project.BNDFILE);
+        IJavaProject jProject = mock(IJavaProject.class, DO_NOT_CALL);
+        doReturn(eclipse).when(jProject)
+            .getProject();
+        ICompilationUnit unit = mock(ICompilationUnit.class, DO_NOT_CALL);
+        doReturn(jProject).when(unit)
+            .getJavaProject();
+        IInvocationContext context = mock(IInvocationContext.class, DO_NOT_CALL);
+        doReturn(unit).when(context)
+            .getCompilationUnit();
+
+        sut = new ImportPackageQuickFixProcessor.BndBuildPathHandler(context) {
+            @Override
+            Workspace getWorkspace() throws Exception {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void getFile_shouldReturnFakeFile() {
+        assertThat(sut.getBndFile()).isSameAs(fakeFile);
+    }
+
+    @Test
+    public void newSUT_doesntLoadModel() throws Exception {
+        Field fieldObj = ImportPackageQuickFixProcessor.BndBuildPathHandler.class.getDeclaredField("bndFile");
+        fieldObj.setAccessible(true);
+
+        assertThat(fieldObj.get(sut)).as("value")
+            .isNull();
+    }
+
+    @Test
+    public void buildPath_onEmptyFile_shouldReturnEmptyList() throws Exception {
+        setContents(fakeFile, "");
+        assertThat(sut.getBuildPath()).isEmpty();
+    }
+
+    void setBuildPath(List<VersionedClause> bundles) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("-buildpath: \\\n");
+
+        Iterator<VersionedClause> it = bundles.iterator();
+        VersionedClause value = it.next();
+        while (it.hasNext()) {
+            builder.append('\t')
+                .append(value)
+                .append(",\\\n");
+            value = it.next();
+        }
+        builder.append('\t')
+            .append(value);
+        setContents(fakeFile, builder.toString());
+    }
+
+    @Test
+    public void getBuildPath_containsElements() throws Exception {
+        assertThat(sut.getBuildPath()).isEqualTo(bundles);
+    }
+
+    @Test
+    public void containsBundle_returnsTrue_forContainedBundles() throws Exception {
+        for (VersionedClause bundle : bundles) {
+            assertThat(sut.containsBundle(bundle.getName())).as("bundle:[" + bundle + "]")
+                .isTrue();
+        }
+    }
+
+    @Test
+    public void containsBundle_returnsFalse_forNonContainedBundles() throws Exception {
+        for (String bundle : new String[] {
+            "some.other.bundle", "something.else"
+        }) {
+            assertThat(sut.containsBundle(bundle)).as("bundle:[" + bundle + "]")
+                .isFalse();
+        }
+    }
+
+    @Test
+    public void addBundle_addsBundle() throws Exception {
+        assertThat(contentsOf(fakeFile)).doesNotContain("some.other.bundle");
+        String init = contentsOf(fakeFile);
+        sut.addBundle("some.other.bundle");
+        String after = contentsOf(fakeFile);
+        assertThat(after).isEqualTo(init + ",\\\n\tsome.other.bundle");
+    }
+}

--- a/bndtools.core/test/org/bndtools/core/editors/ImportPackageQuickFixProcessorTest.java
+++ b/bndtools.core/test/org/bndtools/core/editors/ImportPackageQuickFixProcessorTest.java
@@ -1,0 +1,1066 @@
+package org.bndtools.core.editors;
+
+import org.assertj.core.api.Condition;
+import org.bndtools.api.ILogger;
+import org.bndtools.core.editors.ImportPackageQuickFixProcessor.AddBundleCompletionProposal;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation;
+import org.eclipse.jdt.ui.text.java.IInvocationContext;
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.osgi.framework.namespace.BundleNamespace;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+import org.osgi.service.repository.Repository;
+
+import aQute.bnd.build.WorkspaceRepository;
+import aQute.bnd.build.model.clauses.VersionedClause;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Domain;
+import aQute.bnd.osgi.resource.CapReqBuilder;
+import aQute.bnd.osgi.resource.ResourceBuilder;
+import aQute.bnd.service.RepositoryPlugin;
+import aQute.lib.strings.Strings;
+
+import static org.eclipse.jdt.core.compiler.IProblem.*;
+import static org.bndtools.core.editors.ImportPackageQuickFixProcessor.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.mockito.Mockito.*;
+
+public class ImportPackageQuickFixProcessorTest {
+
+    private static final String WORKSPACE_REPO = "Workspace repo";
+    private static final String JDT_PROBLEM = "org.eclipse.core.markers.problem";
+
+    private ImportPackageQuickFixProcessor sut;
+
+    private ILogger logger;
+
+    private CompilationUnit cu;
+
+    private List<VersionedClause> buildPath;
+    private CoreException containsBundleException;
+
+    private final Set<String> frameworkBundles = newLinkedHashSet();
+    private final Set<String> eclipseBundles = newLinkedHashSet();
+
+    private List<RepositoryPlugin> plugins;
+
+    private Map<String, Map<String, Collection<Capability>>> repoMap;
+
+    private WorkspaceRepository workspacePlugin;
+    private Repository workspaceRepo;
+
+    private static interface PluginRepo extends RepositoryPlugin, Repository {}
+
+    // This could go into a test utils package somewhere.
+    public static final Answer<?> DO_NOT_CALL = new Answer<Object>() {
+
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            throw new AssertionError("Method should not be called during testing");
+        }
+    };
+
+    private Map<String, Collection<Capability>> getRepoMapFor(String name) {
+        Map<String, Collection<Capability>> thisRepoMap = repoMap.get(name);
+        if (thisRepoMap == null) {
+            thisRepoMap = new HashMap<>();
+            repoMap.put(name, thisRepoMap);
+        }
+        return thisRepoMap;
+    }
+
+    private void clearRepos() {
+        repoMap.clear();
+        frameworkBundles.clear();
+        eclipseBundles.clear();
+    }
+
+    static final Pattern FILTER = Pattern.compile(Pattern.quote(PackageNamespace.PACKAGE_NAMESPACE) + "\\s*=\\s*([^)= ]*)\\s*[)]");
+
+    private void mockFindProviders(final String name, Repository repo) {
+        doAnswer(new Answer<Map<Requirement, Collection<Capability>>>() {
+
+            @Override
+            public Map<Requirement, Collection<Capability>> answer(InvocationOnMock invocation) throws Throwable {
+                @SuppressWarnings("unchecked")
+                Collection<? extends Requirement> reqs = invocation.getArgumentAt(0, Collection.class);
+                final Map<String, Collection<Capability>> thisRepoMap = getRepoMapFor(name);
+                Map<Requirement, Collection<Capability>> retval = new HashMap<>();
+                int i = 0;
+                for (Requirement req : reqs) {
+                    assertThat(req.getNamespace()).as("[" + i + "]namespace")
+                        .isEqualTo(PackageNamespace.PACKAGE_NAMESPACE);
+                    assertThat(req.getDirectives()).as("[" + i + "]directives")
+                        .containsOnlyKeys(PackageNamespace.REQUIREMENT_FILTER_DIRECTIVE);
+                    final String filter = req.getDirectives()
+                        .get(PackageNamespace.REQUIREMENT_FILTER_DIRECTIVE);
+                    final Matcher matcher = FILTER.matcher(filter);
+                    assertThat(matcher.find()).as("[" + i + "]filter matches " + FILTER)
+                        .isTrue();
+                    final String pkg = matcher.group(1);
+                    final Collection<Capability> caps = thisRepoMap.get(pkg);
+                    retval.put(req, (caps == null ? Collections.emptyList() : caps));
+                    i++;
+                }
+                return retval;
+            }
+
+        }).when(repo)
+            .findProviders(any());
+    }
+
+    private void mockRepositoryPlugin(String name, RepositoryPlugin p) {
+        doReturn(name).when(p)
+            .getName();
+        doReturn("Repository for " + name).when(p)
+            .toString();
+    }
+
+    private void buildMockPluginRepo(String name) {
+        PluginRepo p = mock(PluginRepo.class, DO_NOT_CALL);
+        mockRepositoryPlugin(name, p);
+        mockFindProviders(name, p);
+        plugins.add(p);
+    }
+
+    // Add the capabilities that describe a bundle to a fake repo.
+    private void addBundleToRepo(String repo, String bsn, VersionedClause... exports) {
+        final Map<String, Collection<Capability>> thisRepoMap = getRepoMapFor(repo);
+
+        ResourceBuilder resource = new ResourceBuilder();
+
+        Attrs attrs = new Attrs();
+        attrs.put(Constants.BUNDLE_SYMBOLICNAME, bsn);
+        Domain manifest = Domain.domain(attrs);
+
+        try {
+            resource.addManifest(manifest);
+            attrs = new Attrs();
+            attrs.put(BundleNamespace.BUNDLE_NAMESPACE, bsn);
+            resource.addCapability(CapReqBuilder.getCapabilityFrom(BundleNamespace.BUNDLE_NAMESPACE, attrs));
+            for (
+
+            VersionedClause exportVersion : exports) {
+                final String export = exportVersion.getName();
+                if (export.equals("org.osgi.framework")) {
+                    frameworkBundles.add(bsn);
+                }
+                if (export.equals("org.eclipse.ui")) {
+                    eclipseBundles.add(bsn);
+                }
+                Attrs pkgAttrs = new Attrs();
+                pkgAttrs.put(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, exportVersion.getVersionRange());
+                resource.addExportPackage(export, pkgAttrs);
+            }
+            Resource res = resource.build();
+            for (Capability cap : res.getCapabilities(PackageNamespace.PACKAGE_NAMESPACE)) {
+                String export = cap.getAttributes()
+                    .get(PackageNamespace.PACKAGE_NAMESPACE)
+                    .toString();
+                Collection<Capability> bundles = thisRepoMap.get(export);
+                if (bundles == null) {
+                    bundles = new HashSet<>();
+                    thisRepoMap.put(export, bundles);
+                }
+                bundles.add(cap);
+            }
+        } catch (Exception e) {
+            fail("Exception trying to add dummy bundle " + bsn + " to test repo", e);
+        }
+    }
+
+    @Test
+    // Meta-test
+    public void addBundleToRepo_createsCorrectCapability() throws Exception {
+        clearRepos();
+        Attrs v100 = new Attrs();
+        v100.put(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, "1.0.0");
+        Attrs v110 = new Attrs();
+        v110.put(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, "1.1.0");
+        addBundleToRepo("Repo 1", "my.test.bundle", new VersionedClause("org.osgi.framework", v100), new VersionedClause("my.test.pkg", v110));
+        Map<String, Collection<Capability>> caps = repoMap.get("Repo 1");
+
+        assertThat(caps).as("map keys")
+            .containsKeys("org.osgi.framework", "my.test.pkg");
+
+        assertThat(frameworkBundles).as("framework bundle")
+            .containsExactly("my.test.bundle");
+
+        Resource bundleResource = null;
+
+        for (Map.Entry<String, Collection<Capability>> entry : caps.entrySet()) {
+            Collection<Capability> packageCaps = entry.getValue();
+            assertThat(packageCaps).isNotNull()
+                .hasSize(1);
+            for (Capability pkg : packageCaps) {
+                assertThat(pkg).as("pkg")
+                    .isNotNull();
+                assertThat(pkg.getResource()).as("resource")
+                    .isNotNull();
+                if (bundleResource == null) {
+                    bundleResource = pkg.getResource();
+                } else {
+                    assertThat(pkg.getResource()).as("resource")
+                        .isSameAs(bundleResource);
+                }
+            }
+        }
+        assertThat(bundleResource).as("bundleResource")
+            .isNotNull();
+    }
+
+    // This could be better put in a test utils class somewhere if such a thing existed.
+    public static void setFinalStatic(Class<?> clazz, String field, Object newValue) throws Exception {
+        Field fieldObj = clazz.getDeclaredField(field);
+        fieldObj.setAccessible(true);
+
+        // remove final modifier from field
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(fieldObj, fieldObj.getModifiers() & ~Modifier.FINAL);
+
+        fieldObj.set(null, newValue);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        sut = new FakeImportPackageQuickFixProcessor();
+        plugins = new ArrayList<>();
+        repoMap = new HashMap<>();
+
+        logger = mock(ILogger.class);
+        setFinalStatic(ImportPackageQuickFixProcessor.class, "logger", logger);
+
+        workspacePlugin = mock(WorkspaceRepository.class, DO_NOT_CALL);
+        workspaceRepo = mock(Repository.class, DO_NOT_CALL);
+        mockRepositoryPlugin(WORKSPACE_REPO, workspacePlugin);
+        mockFindProviders(WORKSPACE_REPO, workspaceRepo);
+        plugins.add(workspacePlugin);
+
+        buildMockPluginRepo("Repo 1");
+        buildMockPluginRepo("Repo 2");
+
+        Attrs v110 = new Attrs();
+        v110.put(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, "1.1.0");
+        Attrs v100 = new Attrs();
+        v100.put(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, "1.0.0");
+        Attrs v201 = new Attrs();
+        v201.put(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, "2.0.1");
+        addBundleToRepo("Repo 1", "my.test.bundle", new VersionedClause("org.osgi.framework", v100), new VersionedClause("org.eclipse.ui", v110), new VersionedClause("test", v110), new VersionedClause("Test", v201));
+        addBundleToRepo("Repo 2", "my.second.bundle", new VersionedClause("org.osgi.framework", v110), new VersionedClause("test", v100), new VersionedClause("Test", v110));
+        addBundleToRepo(WORKSPACE_REPO, "my.eclipse.bundle", new VersionedClause("org.eclipse.ui", v201), new VersionedClause("my.workspace.only.pkg", v110));
+
+        // Uncomment if you need to debug the test setup.
+        // dumpRepo();
+
+        buildPath = new ArrayList<>();
+    }
+
+    private void assertThatContainsFrameworkBundles(IJavaCompletionProposal[] props) {
+        assertThat(props).hasSize(frameworkBundles.size())
+            .haveExactly(1, allOf(suggestsBundle("my.test.bundle", "Repo 1"), withRelevance(ADD_BUNDLE)))
+            .haveExactly(1, allOf(suggestsBundle("my.second.bundle", "Repo 2"), withRelevance(ADD_BUNDLE)));
+    }
+
+    private void setupAST(String source) {
+        ASTParser parser = ASTParser.newParser(AST.JLS8);
+        @SuppressWarnings("rawtypes")
+        Map options = JavaCore.getOptions();
+        // Need to set 1.5 or higher for the "import static" syntax to work.
+        // Need to set 1.8 or higher to test parameterized type usages.
+        JavaCore.setComplianceOptions(JavaCore.VERSION_1_8, options);
+        parser.setCompilerOptions(options);
+        parser.setSource(source.toCharArray());
+        parser.setKind(ASTParser.K_COMPILATION_UNIT);
+        cu = (CompilationUnit) parser.createAST(null);
+    }
+
+    private void addToBuildPath(VersionedClause bundle) {
+        buildPath.add(bundle);
+    }
+
+    private void addToBuildPath(String bundle) {
+        buildPath.add(new VersionedClause(bundle, new Attrs()));
+    }
+
+    private static final String CLASS_HEADER = "class Test {";
+    private static final String CLASS_FOOTER = " var};";
+
+    @Test
+    // Internal test for a fairly complicated helper method.
+    public void testGetProblems() {
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+            getProblems("import `my.pkg.*';", new int[0]);
+        });
+        List<IProblemLocation> probs = getProblems("import ``my.`p'kg'.*';", ImportNotFound, UndefinedType, AmbiguousField);
+        assertThat(cu.toString()
+            .trim()).as("source")
+                .isEqualTo("import my.pkg.*;");
+        assertThat(probs).hasSize(3);
+        IProblemLocation loc;
+        loc = probs.get(0);
+        assertThat(loc.getProblemId()).as("problem 0")
+            .isEqualTo(ImportNotFound);
+        assertThat(loc.getOffset()).as("offset 0")
+            .isEqualTo(10);
+        assertThat(loc.getLength()).as("length 0")
+            .isEqualTo(1);
+        loc = probs.get(1);
+        assertThat(loc.getProblemId()).as("problem 1")
+            .isEqualTo(UndefinedType);
+        assertThat(loc.getOffset()).as("offset 1")
+            .isEqualTo(7);
+        assertThat(loc.getLength()).as("length 1")
+            .isEqualTo(6);
+        loc = probs.get(2);
+        assertThat(loc.getProblemId()).as("problem 2")
+            .isEqualTo(AmbiguousField);
+        assertThat(loc.getOffset()).as("offset 2")
+            .isEqualTo(7);
+        assertThat(loc.getLength()).as("length 2")
+            .isEqualTo(8);
+    }
+
+    /**
+     * Processes "marked source" to generate an AST with associated {@link IProblemLocation} instances. The "marked
+     * source" consists of plain Java source, with "`" to mark the start of a problem and "'" to mark the end. This
+     * syntax will obviously not handle source with character literals well (or strings with embedded ' characters), but
+     * that doesn't matter for this test usage. Marked problems can be nested, but cannot overlap as the closing "'" is
+     * always paired with the most recent starting "`".<br>
+     * The IDs for the problems are taken from the supplied <tt>problemIds</tt> array. They are applied in the order
+     * that the closing "'" characters are found. If the number of supplied problemIds is not equal to the number of
+     * problems marked in the source, the method will assert.<br>
+     * The method finally calls {@link #setupAST(String)} to set up the AST corresponding to the supplied source after
+     * the markers have been stripped.
+     *
+     * @param markedSource The string containing the marked-up Java source.
+     * @param problemIds Array of problem IDs used when building the IProblemLocation objects. It is expected that the
+     *            number of elements in this array will match the number of "`'" pairs in the marked source.
+     * @return The {@link List} of {@link IProblemLocation} objects that correspond to the markers in the source.
+     */
+    private List<IProblemLocation> getProblems(String markedSource, int... problemIds) {
+        List<IProblemLocation> problems = new ArrayList<>(10);
+        StringBuilder source = new StringBuilder(markedSource.length());
+        Deque<Integer> starts = new ArrayDeque<>();
+
+        int problemIndex = 0;
+        int j = 0;
+        for (int i = 0; i < markedSource.length(); i++) {
+            char current = markedSource.charAt(i);
+            switch (current) {
+                case '`' :
+                    starts.push(j);
+                    break;
+                case '\'' :
+                    int currentStart = starts.isEmpty() ? 0 : starts.pop();
+                    assertThat(problemIndex).as("getProblems() problem count")
+                        .isLessThan(problemIds.length);
+                    problems.add(new ProblemLocation(currentStart, j - currentStart, problemIds[problemIndex++], new String[0], true, JDT_PROBLEM));
+                    break;
+                default :
+                    source.append(current);
+                    j++;
+                    break;
+            }
+        }
+        assertThat(problems).as("getProblems() array length")
+            .hasSize(problemIds.length);
+        setupAST(source.toString());
+        return problems;
+    }
+
+    // If there are no markers in the source, wrap the whole string in a pair of markers.
+    private static String autoMark(String source) {
+        return source.indexOf('`') == -1 ? '`' + source + '\'' : source;
+    }
+
+    private AddBundleCompletionProposal[] proposalsForUndefType(String type) {
+        final String markedSource = CLASS_HEADER + autoMark(type) + CLASS_FOOTER;
+        List<IProblemLocation> locs = getProblems(markedSource, UndefinedType);
+
+        return proposalsFor(new FakeInvocationContext(CLASS_HEADER.length(), 0), locs);
+    }
+
+    // Automatically mark up the full import statement if there is no marker.
+    private AddBundleCompletionProposal[] proposalsForImport(String imp) {
+        final String markedSource = "import " + autoMark(imp) + ';';
+
+        List<IProblemLocation> locs = getProblems(markedSource, ImportNotFound);
+
+        return proposalsFor(new FakeInvocationContext(7, 0), locs);
+    }
+
+    private AddBundleCompletionProposal[] proposalsFor(List<? extends IProblemLocation> locs) {
+        return proposalsFor(new FakeInvocationContext(), locs);
+    }
+
+    private AddBundleCompletionProposal[] proposalsFor(IInvocationContext context, List<? extends IProblemLocation> locs) {
+        final AtomicReference<IJavaCompletionProposal[]> ref = new AtomicReference<>();
+
+        IProblemLocation[] locArray = new IProblemLocation[locs.size()];
+        assertThatCode(() -> {
+            ref.set(sut.getCorrections(context, locs.toArray(locArray)));
+        }).doesNotThrowAnyException();
+
+        final IJavaCompletionProposal[] props = ref.get();
+        if (props == null) {
+            return null;
+        }
+        assertThat(props).as("proposals")
+            .hasOnlyElementsOfType(AddBundleCompletionProposal.class);
+        AddBundleCompletionProposal[] retval = new AddBundleCompletionProposal[props.length];
+        int i = 0;
+        for (IJavaCompletionProposal prop : props) {
+            retval[i++] = (AddBundleCompletionProposal) prop;
+        }
+        return retval;
+    }
+
+    @Test
+    public void hasCorrections_withProblemIdImportPackage_returnsTrue() {
+        assertThat(sut.hasCorrections(null, ImportNotFound)).isTrue();
+    }
+
+    @Test
+    public void hasCorrections_withProblemIdUndefinedType_returnsTrue() {
+        assertThat(sut.hasCorrections(null, UndefinedType)).isTrue();
+    }
+
+    @Test
+    public void hasCorrections_withOtherProblemId_returnsFalse() {
+        assertThat(sut.hasCorrections(null, UnusedImport)).isFalse();
+    }
+
+    @Test
+    public void getCorrections_withNoMatches_forUndefType_returnsNull() {
+        assertThat(proposalsForUndefType("my.unknown.type.MyClass")).isNull();
+    }
+
+    @Test
+    public void getCorrections_withUnqualifiedType_returnsNull() {
+        assertThat(proposalsForUndefType("BundleActivator")).isNull();
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedUnqualifiedType_returnsNull() {
+        assertThat(proposalsForUndefType("@NonNull `BundleActivator'")).isNull();
+    }
+
+    @Test
+    public void getCorrections_withInnerType_returnsNull() {
+        assertThat(proposalsForUndefType("BundleActivator.Inner")).isNull();
+    }
+
+    @Test
+    public void getCorrections_withMarkerOnSimpleInnerType_returnsNull() {
+        assertThat(proposalsForUndefType("`BundleActivator'.Inner")).isNull();
+    }
+
+    @Test
+    public void getCorrections_withFQType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.BundleActivator"));
+    }
+
+    @Test
+    public void getCorrections_withMarkerOnSimpleType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.`BundleActivator'"));
+    }
+
+    @Test
+    public void getCorrections_withMarkerOnPackage_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`org.osgi.framework'.BundleActivator"));
+    }
+
+    @Test
+    public void getCorrections_withFQNestedType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.BundleActivator.Inner"));
+    }
+
+    @Test
+    public void getCorrections_withFQNestedType_andMarkerOnInnerType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.BundleActivator.`Inner'"));
+    }
+
+    @Test
+    public void getCorrections_withFQNestedType_andMarkerOnOuterType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.`BundleActivator'.Inner"));
+    }
+
+    @Test
+    // Annotated type cause the AST to generate a NameQualifiedType; need to handle this case.
+    public void getCorrections_withAnnotatedFQNestedType_andMarkerOnOuterType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.`BundleActivator'.@NotNull Inner"));
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedFQType_andPackageMarked_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`org.osgi.framework'.@NotNull BundleActivator"));
+    }
+
+    @Test
+    public void getCorrections_withFQType_andOneLevelPackage_suggestsBundles() {
+        // pkgMap.put("test", frameworkBundles);
+        assertThatContainsFrameworkBundles(proposalsForUndefType("test.BundleActivator"));
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedFQType_andOneLevelPackage_suggestsBundles() {
+        // pkgMap.put("test", frameworkBundles);
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`test'.@NotNull BundleActivator"));
+    }
+
+    @Test
+    // Using a parameterized type as a qualifier forces Eclipse AST to generate a QualifiedType
+    public void getCorrections_withParameterisedOuterType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`org.osgi.framework'.BundleActivator<String>.Inner.@NotNull BundleActivator"));
+    }
+
+    @Test
+    @Ignore("Not yet implemented")
+    // Force Eclipse AST to generate a QualifiedType
+    public void getCorrections_withParameterisedOuterType_andMarkerOnInner_suggestsBundles() {
+        // Due to the structure of QualifiedType (the qualifier is a Type rather than simply a Name), it becomes
+        // a little more complicated to recurse back through the type definition to get the package name.
+        // Moreover, the JDT doesn't seem to mark the inner type if it can't find the package - it will mark
+        // the package instead. So this kind of construction is unlikely to occur in practice. If there becomes
+        // a need, this test can be re-enabled and implemented.
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.BundleActivator<String>.`Inner'.@NotNull BundleActivator"));
+    }
+
+    @Test
+    public void getCorrections_withUnnnotatedFQArrayType_andFullTypeMarked_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`org.osgi.framework.BundleActivator'[]"));
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedFQArrayType_andPackageMarked_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`org.osgi.framework'.@NotNull BundleActivator[]"));
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedFQDoubleArrayType_andPackageMarked_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`org.osgi.framework'.@NotNull BundleActivator[][]"));
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedFQType_andPackagePartMarked_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`org.osgi'.framework.@NotNull BundleActivator"));
+    }
+
+    @Test
+    public void getCorrections_withParameter_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("List<`org.osgi'.framework.@NotNull BundleActivator>"));
+    }
+
+    @Test
+    public void getCorrections_withWildcardBound_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("List<? extends `org.osgi'.framework.BundleActivator>"));
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedWildcardBound_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("List<? extends `org.osgi'.framework.@NotNull BundleActivator>"));
+    }
+
+    @Test
+    public void getCorrections_withUnqualifiedNameType_returnsNull() {
+        // If the type is a simple name, it must refer to a type and not a package; therefore don't provide package
+        // import suggestions even if we have a package with the matching name.
+        assertThat(proposalsForUndefType("Test")).as("capitalized")
+            .isNull();
+        assertThat(proposalsForUndefType("test")).as("uncapitalized")
+            .isNull();
+    }
+
+    @Test
+    public void getCorrection_withParameterizedType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("`org.osgi.framework'.BundleActivator<String>"));
+    }
+
+    @Test
+    public void getCorrection_withParameterizedType_thatLooksLikePackage_returnsNull() {
+        assertThat(proposalsForUndefType("org.osgi.framework<String>.`BundleActivator'"));
+    }
+
+    // Enabling the handling of markers like these is feasible but complicates the code a fair bit. Also, the JDT
+    // doesn't seem to mark it like this, but if anything will do the whole string or part of the package string.
+    // Leaving the test here in case we decide to add the functionality in the future, but at the moment it won't
+    // pass.
+    @Test
+    public void getCorrections_withAnnotatedFQType_andMarkerOnType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.@NotNull `BundleActivator'"));
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedFQNestedType_andMarkerOnInnerType_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.BundleActivator.@NotNull `Inner'"));
+    }
+
+    @Test
+    public void getCorrections_withAnnotatedFQType_andWholeDecMarked_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForUndefType("org.osgi.framework.@NotNull BundleActivator"));
+    }
+
+    @Test
+    public void getCorrections_withNoMatches_returnsNull() {
+        clearRepos();
+        assertThat(proposalsForImport("org.osgi.framework.*")).as("import")
+            .isNull();
+        assertThat(proposalsForUndefType("org.osgi.framework.BundleActivator")).as("type")
+            .isNull();
+    }
+
+    // This method is useful when debugging.
+    @SuppressWarnings("unused")
+    private void dumpRepo() {
+        for (Map.Entry<String, Map<String, Collection<Capability>>> entry : repoMap.entrySet()) {
+            System.err.println("Repository: " + entry.getKey());
+            for (Map.Entry<String, Collection<Capability>> inner : entry.getValue()
+                .entrySet()) {
+                System.err.println("   package: " + inner.getKey());
+                for (Capability cap : inner.getValue()) {
+                    System.err.println("        cap: " + cap + " from resource " + cap.getResource());
+                }
+            }
+
+        }
+    }
+
+    @Test
+    public void getCorrections_withOnDemandImport_altPackage_suggestsBundles() {
+        AddBundleCompletionProposal[] props = proposalsForImport("`org.eclipse'.ui.*");
+        assertThat(props).hasSize(eclipseBundles.size())
+            .haveExactly(1, allOf(suggestsBundle("my.test.bundle", "Repo 1"), withRelevance(ADD_BUNDLE)))
+            .haveExactly(1, allOf(suggestsBundle("my.eclipse.bundle", WORKSPACE_REPO), withRelevance(ADD_BUNDLE_WORKSPACE)));
+    }
+
+    @Test
+    public void getCorrections_withOnlyIrrelvantProblems_skipsAll_andReturnsNull() {
+        List<IProblemLocation> locs = getProblems("import `org.`osgi'.framework'.*", UnusedImport, AmbiguousType);
+
+        assertThat(proposalsFor(locs)).isNull();
+    }
+
+    @Test
+    public void getCorrections_skipsIrrelevantProblems_andReturnsBundles() {
+        List<IProblemLocation> locs = getProblems("import `org.osgi'`.framework'.*", ImportNotFound, UnusedImport);
+
+        assertThatContainsFrameworkBundles(proposalsFor(locs));
+    }
+
+    @Test
+    public void getCorrections_withMarkerInMiddle_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("org.`osgi.'framework.*"));
+    }
+
+    @Test
+    public void getCorrections_withMarkerAroundWildcard_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("org.`osgi.framework.*'"));
+    }
+
+    @Test
+    public void getCorrections_withMarkerAroundClass_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("org.`osgi.framework.BundleActivator'"));
+    }
+
+    @Test
+    public void getCorrections_withMarkerAroundStatic_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("`static org.osgi.framework'.Clazz.member"));
+    }
+
+    @Test
+    public void getCorrections_withClassImport_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("`org.osgi'.framework.BundleActivator"));
+    }
+
+    @Test
+    public void getCorrections_withInnerClassImport_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("`org.osgi'.framework.BundleActivator.Inner"));
+    }
+
+    @Test
+    public void getCorrections_withOnDemandImport_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("`org.osgi'.framework.*"));
+    }
+
+    @Test
+    public void getCorrections_withOnDemandStaticImport_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("static `org.osgi'.framework.Clazz.*"));
+    }
+
+    @Test
+    public void getCorrections_withStaticImport_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("static `org.osgi'.framework.Clazz.member"));
+    }
+
+    @Test
+    public void getCorrections_whenUnversionedBundleAlreadyIncluded_returnsNull() {
+        addToBuildPath("my.test.bundle");
+        AddBundleCompletionProposal[] props = proposalsForImport("`org.osgi'.framework.*");
+        assertThat(props).hasSize(1)
+            .haveExactly(1, suggestsBundle("my.second.bundle"));
+    }
+
+    @Test
+    public void getCorrections_whenVersionedBundleAlreadyIncluded_returnsNull() {
+        Attrs attrs = new Attrs();
+        attrs.put("version", "1.0.2");
+        addToBuildPath(new VersionedClause("my.second.bundle", attrs));
+        AddBundleCompletionProposal[] props = proposalsForImport("`org.osgi'.framework.*");
+        assertThat(props).hasSize(1)
+            .haveExactly(1, suggestsBundle("my.test.bundle"));
+    }
+
+    @Test
+    public void getCorrections_withSimplePackageName_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("test.Clazz"));
+    }
+
+    @Test
+    public void getCorrections_withOnDemandSimplePackageName_suggestsBundles() {
+        assertThatContainsFrameworkBundles(proposalsForImport("`test'.*"));
+    }
+
+    @Test
+    public void getCorrections_withOnDemandSimpleCapitalisedPackageName_suggestsBundles() {
+        // The qualifier for a class in a package name that is only one layer deep
+        // is a simple name and not a qualified name. Normally we assume that if it is
+        // capitalized it must refer to a type rather than a package, but syntactically
+        // this isn't permitted in the first position of an import statement, so we know
+        // that a package must be meant.
+        assertThatContainsFrameworkBundles(proposalsForImport("`Test'.*"));
+    }
+
+    @Test
+    public void getCorrections_withOnDemandStatic_forClassInMainNamespace_returnsNull() {
+        // The qualifier for a class in a package name that is only one layer deep
+        // is a simple name and not a qualified name. Make sure that
+        // getPackageName can handle that.
+        assertThat(proposalsForImport("static >Test<.*")).isNull();
+    }
+
+    @Test
+    public void getCorrections_forClassInMainNamespace_returnsNull() {
+        // The qualifier for a class in a package name that is only one layer deep
+        // is a simple name and not a qualified name. Make sure that
+        // getPackageName can handle that.
+        assertThat(proposalsForImport("Test")).isNull();
+    }
+
+    @Test
+    public void getCorrections_forStaticImportClassInMainNamespace_returnsNull() {
+        // The qualifier for a class in a package name that is only one layer deep
+        // is a simple name and not a qualified name. Make sure that
+        // getPackageName can handle that.
+        assertThat(proposalsForImport("static Test.member")).isNull();
+    }
+
+    @Test
+    public void getCorrections_forKnownImport_fromDifferentPackage_suggestsBundles() {
+        List<IProblemLocation> locs = getProblems("package my.other.pkg;\n\nimport `org.osgi'.framework.Clazz;", ImportNotFound);
+
+        assertThatContainsFrameworkBundles(proposalsFor(locs));
+    }
+
+    @Test
+    public void getCorrections_forKnownImport_fromSamePackage_returnsNull() {
+        List<IProblemLocation> locs = getProblems("package org.osgi.framework;\n\nimport `org.osgi.framework'.Clazz;", ImportNotFound);
+
+        assertThat(proposalsFor(locs)).isNull();
+    }
+
+    @Test
+    public void getCorrections_forWorkspaceOnlyImport_suggestsBundle_withWorkspaceRelevance() {
+        AddBundleCompletionProposal[] props = proposalsForImport("`my.workspace.only.pkg'.*");
+        assertThat(props).hasSize(1)
+            .haveExactly(1, allOf(suggestsBundle("my.eclipse.bundle"), withRelevance(ADD_BUNDLE_WORKSPACE)));
+    }
+
+    @Test
+    public void getCorrections_forBundleInTwoRepos_describesBundles() {
+        addBundleToRepo("Repo 2", "my.test.bundle", new VersionedClause("org.osgi.framework", new Attrs()));
+        AddBundleCompletionProposal[] props = proposalsForImport("`org.osgi.framework'.*");
+        assertThat(props).haveExactly(1, suggestsBundle("my.test.bundle", "Repo 1", "Repo 2"));
+    }
+
+    @Test
+    public void getCorrections_forBundleInThreeRepos_describesBundles() {
+        addBundleToRepo("Repo 2", "my.test.bundle", new VersionedClause("org.osgi.framework", new Attrs()));
+        addBundleToRepo(WORKSPACE_REPO, "my.test.bundle", new VersionedClause("org.osgi.framework", new Attrs()));
+        AddBundleCompletionProposal[] props = proposalsForImport("`org.osgi.framework'.*");
+        assertThat(props).haveExactly(1, allOf(suggestsBundle("my.test.bundle", "Repo 1", WORKSPACE_REPO, "Repo 2"), withRelevance(ADD_BUNDLE_WORKSPACE)));
+    }
+
+    Exception makeSUTgetWSRepo_throwException() {
+        final Exception ex = new Exception();
+        sut = new FakeImportPackageQuickFixProcessor() {
+            @Override
+            Repository getWorkspaceRepo() throws Exception {
+                throw (Exception) ex.fillInStackTrace();
+            }
+        };
+        return ex;
+    }
+
+    @Test
+    public void getCorrections_forWorkspaceOnlyImport_whenWorkspaceFails_logsErrorOnce_andReturnsNull() {
+        Exception ex = makeSUTgetWSRepo_throwException();
+
+        AddBundleCompletionProposal[] props = proposalsForImport("`my.workspace.only.pkg'.*");
+
+        assertThat(props).as("proposals")
+            .isNull();
+        verify(logger, times(1)).logError("Error trying to fetch the repository for the current workspace", ex);
+    }
+
+    @Test
+    public void getCorrections_whenWorkspaceFails_returnsProposalsFromNonWorkspaceRepos() {
+        makeSUTgetWSRepo_throwException();
+
+        AddBundleCompletionProposal[] props = proposalsForImport("`org.eclipse.ui'.*");
+
+        assertThat(props).hasSize(1)
+            .have(suggestsBundle("my.test.bundle"));
+    }
+
+    @Test
+    public void getCorrections_whenWorkspaceFails_andMultiplePackages_onlyLogsErrorOnce() {
+        Exception ex = makeSUTgetWSRepo_throwException();
+
+        List<IProblemLocation> locs = getProblems("import `org.eclipse.ui'.*; import `org.osgi.framework'.*;", new int[] {
+            ImportNotFound, ImportNotFound
+        });
+
+        proposalsFor(new FakeInvocationContext(7, 0), locs);
+
+        verify(logger, times(1)).logError("Error trying to fetch the repository for the current workspace", ex);
+    }
+
+    @Test
+    public void getCorrections_whenContainsBundleFails_throwsException() {
+        containsBundleException = new CoreException(new Status(IStatus.ERROR, "bundle", "Hi there"));
+
+        List<IProblemLocation> locs = getProblems("import `org.osgi.framework'.*;", ImportNotFound);
+        IProblemLocation[] locArray = new IProblemLocation[locs.size()];
+        assertThatExceptionOfType(CoreException.class).isThrownBy(() -> {
+            sut.getCorrections(new FakeInvocationContext(), locs.toArray(locArray));
+        })
+            .isSameAs(containsBundleException);
+    }
+
+    static class MatchDisplayString extends Condition<IJavaCompletionProposal> {
+        private final Pattern p;
+        private final Set<String> repos;
+
+        public MatchDisplayString(String bundle, String... repos) {
+            super(Strings.format("A suggestion for bundle '%s'", bundle) + ((repos != null && repos.length > 0) ? Strings.format(" from repos %s", Arrays.toString(repos)) : ""));
+            String re = String.format("^Add bundle '%s' to Bnd build path", bundle);
+            if (repos != null) {
+                re += " [(]from (.*?)(?: [+] (?:(1) other|(\\d+) others))?[)]$";
+                this.repos = new HashSet<>();
+                for (String repo : repos) {
+                    this.repos.add(repo);
+                }
+            } else {
+                this.repos = null;
+            }
+            p = Pattern.compile(re);
+        }
+
+        @Override
+        public boolean matches(IJavaCompletionProposal value) {
+            if (value == null || value.getDisplayString() == null) {
+                return false;
+            }
+            final Matcher m = p.matcher(value.getDisplayString());
+            if (!m.find()) {
+                return false;
+            }
+            if (repos == null || repos.isEmpty()) {
+                return true;
+            }
+            if (!repos.contains(m.group(1))) {
+                return false;
+            }
+            if (m.group(2) != null) {
+                return repos.size() == 2;
+            }
+            if (m.group(3) != null) {
+                int v = Integer.valueOf(m.group(3));
+                return repos.size() == v + 1;
+            }
+            return repos.size() == 1;
+        }
+    }
+
+    static Condition<IJavaCompletionProposal> suggestsBundle(String bundle, String... repos) {
+        return new MatchDisplayString(bundle, repos);
+    }
+
+    static Condition<IJavaCompletionProposal> withRelevance(final int relevance) {
+        return new Condition<IJavaCompletionProposal>("Suggestion has relevance " + relevance) {
+            @Override
+            public boolean matches(IJavaCompletionProposal value) {
+                return value != null && value.getRelevance() == relevance;
+            }
+        };
+    }
+
+    class FakeInvocationContext implements IInvocationContext {
+
+        NodeFinder fNodeFinder;
+        int fSelectionOffset;
+        int fSelectionLength;
+
+        public FakeInvocationContext() {
+            this(0, 0);
+        }
+
+        public FakeInvocationContext(int offset, int length) {
+            fSelectionOffset = offset;
+            fSelectionLength = length;
+        }
+
+        @Override
+        public ICompilationUnit getCompilationUnit() {
+            fail("Fake method not implemented - should not be called during testing");
+            return null;
+        }
+
+        @Override
+        public int getSelectionOffset() {
+            return fSelectionOffset;
+        }
+
+        @Override
+        public int getSelectionLength() {
+            return fSelectionLength;
+        }
+
+        @Override
+        public CompilationUnit getASTRoot() {
+            return cu;
+        }
+
+        /*
+         * Copied from org.eclipse.jdt.internal.ui.text.correction.AssistContext;
+         * @see org.eclipse.jdt.ui.text.java.IInvocationContext#getCoveringNode()
+         */
+        @Override
+        public ASTNode getCoveringNode() {
+            if (fNodeFinder == null) {
+                fNodeFinder = new NodeFinder(getASTRoot(), getSelectionOffset(), getSelectionLength());
+            }
+            return fNodeFinder.getCoveringNode();
+        }
+
+        /*
+         * (non-Javadoc)
+         * @see org.eclipse.jdt.ui.text.java.IInvocationContext#getCoveredNode()
+         */
+        @Override
+        public ASTNode getCoveredNode() {
+            if (fNodeFinder == null) {
+                fNodeFinder = new NodeFinder(getASTRoot(), getSelectionOffset(), getSelectionLength());
+            }
+            return fNodeFinder.getCoveredNode();
+        }
+    }
+
+    class FakeBndBuildPathHandler extends BndBuildPathHandler {
+
+        public FakeBndBuildPathHandler(IInvocationContext context) {
+            super(context);
+        }
+
+        @Override
+        void loadFileInfo() {
+            fail("Fake method not implemented - should not be called during testing");
+        }
+
+        @Override
+        void loadModel() {
+            fail("Fake method not implemented - should not be called during testing");
+        }
+
+        @Override
+        public List<VersionedClause> getBuildPath() {
+            return buildPath;
+        }
+
+        @Override
+        public boolean containsBundle(String bundle) throws CoreException {
+            if (containsBundleException != null) {
+                throw (CoreException) containsBundleException.fillInStackTrace();
+            }
+            for (VersionedClause versionedBundle : buildPath) {
+                if (versionedBundle.getName()
+                    .equals(bundle)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void addBundle(VersionedClause versionedBundle) {
+            buildPath.add(versionedBundle);
+        }
+    }
+
+    class FakeImportPackageQuickFixProcessor extends ImportPackageQuickFixProcessor {
+
+        @Override
+        List<RepositoryPlugin> listRepositories() {
+            return plugins;
+        }
+
+        @Override
+        Repository getWorkspaceRepo() throws Exception {
+            return workspaceRepo;
+        }
+
+        @Override
+        BndBuildPathHandler getBuildPathHandler(IInvocationContext context) {
+            return new FakeBndBuildPathHandler(context);
+        }
+    }
+}

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -10,6 +10,7 @@ org.slf4j:slf4j-simple:1.7.13
 org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.12_1
 org.mockito:mockito-core:1.10.19
 org.objenesis:objenesis:2.2
+org.assertj:assertj-core:3.9.0
 
 com.google.guava:guava:16.0.1
 


### PR DESCRIPTION
This PR is an implementation of #1589.

If you have an import statement for a package/class that is not on the build path, and Bndtools can find one or more bundles that exports that package in the known set of local repositories, then it will add a "quick fixes" to the top of the available quick fixes. Similarly for fully-qualified references to unknown types. 

Bundles from the current workspace will be listed first, then from other repositories.

If you select the "quick fix" for a given bundle, then that bundle will be added to the build path in the `bnd.bnd` file for the current project.

There are some heuristics in there to try to distinguish between class names and package names where it is syntactically ambiguous (basically, in most cases it is assumed to be a package name if it starts with a lower case letter and a class name otherwise).

I tried to have a fairly comprehensive set of automated tests as well, though I know I fell short of 100% coverage.

Possible future enhancements:

# Demote suggestions to add a bundle if a different bundle is already on the build path that exports the same package.
# Add auto-completion proposals for types/imports of packages from known bundles.
# Index the exported classes in the bundles as well as the exported packages, so that we could provide type fixes/completions as well as package fixes/completions.