### PR TITLE
Prevent quickfix suggesting that a bundle be added to its own build path

### DIFF
--- a/bndtools.core/src/org/bndtools/core/editors/ImportPackageQuickFixProcessor.java
+++ b/bndtools.core/src/org/bndtools/core/editors/ImportPackageQuickFixProcessor.java
@@ -103,6 +103,7 @@ public class ImportPackageQuickFixProcessor implements IQuickFixProcessor {
 
     static class BndBuildPathHandler {
         private final IInvocationContext context;
+        private IProject eclipseProject;
         private IFile bndFile;
         private IDocument bndDoc;
         private BndEditModel bndModel;
@@ -130,8 +131,8 @@ public class ImportPackageQuickFixProcessor implements IQuickFixProcessor {
             }
             final ICompilationUnit compUnit = context.getCompilationUnit();
             final IJavaProject java = compUnit.getJavaProject();
-            final IProject eclipse = java.getProject();
-            bndFile = eclipse.getFile(Project.BNDFILE);
+            eclipseProject = java.getProject();
+            bndFile = eclipseProject.getFile(Project.BNDFILE);
         }
 
         Workspace getWorkspace() throws Exception {
@@ -200,7 +201,9 @@ public class ImportPackageQuickFixProcessor implements IQuickFixProcessor {
 
         public boolean containsBundle(String bundle) throws CoreException {
             loadModel();
-            return buildPathBundles.contains(bundle);
+            // TODO: This will need modification to handle sub-bundles as the BSN is derived differently.
+            final String bsn = eclipseProject.getName();
+            return bsn.equals(bundle) || buildPathBundles.contains(bundle);
         }
     }
 

--- a/bndtools.core/test/org/bndtools/core/editors/ImportPackageQuickFixProcessorBndBuildPathHandlerTest.java
+++ b/bndtools.core/test/org/bndtools/core/editors/ImportPackageQuickFixProcessorBndBuildPathHandlerTest.java
@@ -33,6 +33,24 @@ public class ImportPackageQuickFixProcessorBndBuildPathHandlerTest {
 
     private List<VersionedClause> bundles;
     private IFile fakeFile;
+    private final String BSN = "my.self.bundle";
+
+    void setBuildPath(List<VersionedClause> bundles) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("\n-buildpath: \\\n");
+
+        Iterator<VersionedClause> it = bundles.iterator();
+        VersionedClause value = it.next();
+        while (it.hasNext()) {
+            builder.append('\t')
+                .append(value)
+                .append(",\\\n");
+            value = it.next();
+        }
+        builder.append('\t')
+            .append(value);
+        setContents(fakeFile, builder.toString());
+    }
 
     @Before
     public void setUp() {
@@ -47,9 +65,13 @@ public class ImportPackageQuickFixProcessorBndBuildPathHandlerTest {
         IProject eclipse = mock(IProject.class, DO_NOT_CALL);
         doReturn(fakeFile).when(eclipse)
             .getFile(Project.BNDFILE);
+        doReturn(BSN).when(eclipse)
+            .getName();
         IJavaProject jProject = mock(IJavaProject.class, DO_NOT_CALL);
         doReturn(eclipse).when(jProject)
             .getProject();
+        doReturn(BSN).when(jProject)
+            .getElementName();
         ICompilationUnit unit = mock(ICompilationUnit.class, DO_NOT_CALL);
         doReturn(jProject).when(unit)
             .getJavaProject();
@@ -85,23 +107,6 @@ public class ImportPackageQuickFixProcessorBndBuildPathHandlerTest {
         assertThat(sut.getBuildPath()).isEmpty();
     }
 
-    void setBuildPath(List<VersionedClause> bundles) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("-buildpath: \\\n");
-
-        Iterator<VersionedClause> it = bundles.iterator();
-        VersionedClause value = it.next();
-        while (it.hasNext()) {
-            builder.append('\t')
-                .append(value)
-                .append(",\\\n");
-            value = it.next();
-        }
-        builder.append('\t')
-            .append(value);
-        setContents(fakeFile, builder.toString());
-    }
-
     @Test
     public void getBuildPath_containsElements() throws Exception {
         assertThat(sut.getBuildPath()).isEqualTo(bundles);
@@ -123,6 +128,11 @@ public class ImportPackageQuickFixProcessorBndBuildPathHandlerTest {
             assertThat(sut.containsBundle(bundle)).as("bundle:[" + bundle + "]")
                 .isFalse();
         }
+    }
+
+    @Test
+    public void containsBundle_returnsTrue_whenBundleIsSelf() throws Exception {
+        assertThat(sut.containsBundle(BSN)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Quick implementation of a fix for #1865. In summary, altered BndBuildPathHandler so that a bundle is considered to be on its own build path.

This won't work properly on projects that have sub-bundles - that implementation will require a little more surgery (and a little more learning from me on how sub-bundles are structured).