### PR TITLE
build: Use current time as build time stamp

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -43,14 +43,8 @@ gradle.ext.bndWorkspaceConfigure = { workspace ->
   workspace.setProperty('bnd_repourl', uri(bnd_repourl).toString())
   /*
    * Compute the build time stamp. 
-   * If the git workspace is clean, the build time is the time of the head commit.
-   * If the git workspace is dirty, the build time is the current time.
    */
-  if ('git diff --no-ext-diff --quiet'.execute().waitFor() == 0) {
-    workspace.setProperty(Constants.TSTAMP, 'git show --no-patch --format=%ct000'.execute().text.trim())
-  } else {
-    workspace.setProperty(Constants.TSTAMP, Long.toString(System.currentTimeMillis()))
-  }
+  workspace.setProperty(Constants.TSTAMP, Long.toString(System.currentTimeMillis()))
 }
 
 apply plugin: 'biz.aQute.bnd.workspace'


### PR DESCRIPTION
If bnd changes, bndtools used the commit timestamp and then p2 would not
download the updated bndtools plugin. This can cause resolution errors
in eclipse between the updated bnd bundles and the older bndtools
bundles.