### PR TITLE
test: Mark test source entries as test=true 

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/WorkingSetTracker.java
+++ b/bndtools.builder/src/org/bndtools/builder/WorkingSetTracker.java
@@ -101,7 +101,7 @@ public class WorkingSetTracker {
 
     static private void updateWorkingSet(final IWorkingSet wset, final List<IAdaptable> members) {
         IAdaptable[] elements;
-        elements = members.toArray(new IAdaptable[members.size()]);
+        elements = members.toArray(new IAdaptable[0]);
         wset.setElements(elements);
     }
 

--- a/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizard.java
@@ -33,11 +33,13 @@ import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -261,6 +263,8 @@ public class ImportBndWorkspaceWizard extends Wizard implements IImportWizard {
         importSourceAndOutputFolders(bndProject, project, javaProject, monitor);
     }
 
+    private static final IClasspathAttribute TEST = JavaCore.newClasspathAttribute("test", Boolean.TRUE.toString());
+
     private void importSourceAndOutputFolders(Project bndProject, IProject workspaceProject, IJavaProject javaProject, IProgressMonitor monitor) throws Exception {
         // remove defaults
         removeClasspathDefaults(javaProject);
@@ -279,7 +283,7 @@ public class ImportBndWorkspaceWizard extends Wizard implements IImportWizard {
             // will fail
             IPackageFragmentRoot root = javaProject.getPackageFragmentRoot(source);
             List<IClasspathEntry> entries = new ArrayList<>(Arrays.asList(javaProject.getRawClasspath()));
-            entries.add(JavaCore.newSourceEntry(root.getPath(), null, outputRoot.getPath()));
+            entries.add(JavaCore.newSourceEntry(root.getPath(), ClasspathEntry.INCLUDE_ALL, ClasspathEntry.EXCLUDE_NONE, outputRoot.getPath(), ClasspathEntry.NO_EXTRA_ATTRIBUTES));
             javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[0]), monitor);
             createFolderIfNecessary(source, monitor);
         }
@@ -298,7 +302,9 @@ public class ImportBndWorkspaceWizard extends Wizard implements IImportWizard {
             // will fail
             IPackageFragmentRoot root = javaProject.getPackageFragmentRoot(testSource);
             List<IClasspathEntry> entries = new ArrayList<>(Arrays.asList(javaProject.getRawClasspath()));
-            entries.add(JavaCore.newSourceEntry(root.getPath(), null, testOutputRoot.getPath()));
+            entries.add(JavaCore.newSourceEntry(root.getPath(), ClasspathEntry.INCLUDE_ALL, ClasspathEntry.EXCLUDE_NONE, testOutputRoot.getPath(), new IClasspathAttribute[] {
+                TEST
+            }));
             javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[0]), monitor);
             createFolderIfNecessary(testSource, monitor);
         }

--- a/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizard.java
@@ -280,7 +280,7 @@ public class ImportBndWorkspaceWizard extends Wizard implements IImportWizard {
             IPackageFragmentRoot root = javaProject.getPackageFragmentRoot(source);
             List<IClasspathEntry> entries = new ArrayList<>(Arrays.asList(javaProject.getRawClasspath()));
             entries.add(JavaCore.newSourceEntry(root.getPath(), null, outputRoot.getPath()));
-            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), monitor);
+            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[0]), monitor);
             createFolderIfNecessary(source, monitor);
         }
         // Test-Source
@@ -299,7 +299,7 @@ public class ImportBndWorkspaceWizard extends Wizard implements IImportWizard {
             IPackageFragmentRoot root = javaProject.getPackageFragmentRoot(testSource);
             List<IClasspathEntry> entries = new ArrayList<>(Arrays.asList(javaProject.getRawClasspath()));
             entries.add(JavaCore.newSourceEntry(root.getPath(), null, testOutputRoot.getPath()));
-            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), monitor);
+            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[0]), monitor);
             createFolderIfNecessary(testSource, monitor);
         }
 
@@ -365,7 +365,7 @@ public class ImportBndWorkspaceWizard extends Wizard implements IImportWizard {
             } else {
                 entries.add(defaultJREContainerEntry);
             }
-            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), monitor);
+            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[0]), monitor);
         }
     }
 

--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizardPageOne.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizardPageOne.java
@@ -27,8 +27,10 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.ui.wizards.NewJavaProjectWizardPageOne;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -150,6 +152,8 @@ public class NewBndProjectWizardPageOne extends NewJavaProjectWizardPageOne {
         return result.toArray(new IClasspathEntry[0]);
     }
 
+    private static final IClasspathAttribute TEST = JavaCore.newClasspathAttribute("test", Boolean.TRUE.toString());
+
     @Override
     public IClasspathEntry[] getSourceClasspathEntries() {
         IPath projectPath = new Path(getProjectName()).makeAbsolute();
@@ -157,7 +161,7 @@ public class NewBndProjectWizardPageOne extends NewJavaProjectWizardPageOne {
         ProjectPaths projectPaths = ProjectPaths.DEFAULT;
 
         List<IClasspathEntry> newEntries = new ArrayList<IClasspathEntry>(2);
-        newEntries.add(JavaCore.newSourceEntry(projectPath.append(projectPaths.getSrc()), null, projectPath.append(projectPaths.getBin())));
+        newEntries.add(JavaCore.newSourceEntry(projectPath.append(projectPaths.getSrc()), ClasspathEntry.INCLUDE_ALL, ClasspathEntry.EXCLUDE_NONE, projectPath.append(projectPaths.getBin()), ClasspathEntry.NO_EXTRA_ATTRIBUTES));
 
         boolean enableTestSrcDir;
         try {
@@ -174,7 +178,9 @@ public class NewBndProjectWizardPageOne extends NewJavaProjectWizardPageOne {
             enableTestSrcDir = true;
         }
         if (enableTestSrcDir)
-            newEntries.add(JavaCore.newSourceEntry(projectPath.append(projectPaths.getTestSrc()), null, projectPath.append(projectPaths.getTestBin())));
+            newEntries.add(JavaCore.newSourceEntry(projectPath.append(projectPaths.getTestSrc()), ClasspathEntry.INCLUDE_ALL, ClasspathEntry.EXCLUDE_NONE, projectPath.append(projectPaths.getTestBin()), new IClasspathAttribute[] {
+                TEST
+            }));
 
         return newEntries.toArray(new IClasspathEntry[0]);
     }

--- a/bndtools.pde/src/bndtools/pde/target/RepositoryTargetLocation.java
+++ b/bndtools.pde/src/bndtools/pde/target/RepositoryTargetLocation.java
@@ -97,7 +97,7 @@ public class RepositoryTargetLocation extends BndTargetLocation {
 
             monitor.done();
 
-            return bundles.toArray(new TargetBundle[bundles.size()]);
+            return bundles.toArray(new TargetBundle[0]);
         } catch (CoreException e) {
             throw e;
         } catch (Exception e) {

--- a/bndtools.pde/src/bndtools/pde/target/RunDescriptorTargetLocation.java
+++ b/bndtools.pde/src/bndtools/pde/target/RunDescriptorTargetLocation.java
@@ -109,7 +109,7 @@ public class RunDescriptorTargetLocation extends BndTargetLocation {
 
             monitor.done();
 
-            return bundles.toArray(new TargetBundle[bundles.size()]);
+            return bundles.toArray(new TargetBundle[0]);
         } catch (CoreException e) {
             throw e;
         } catch (Exception e) {

--- a/org.bndtools.templating/src/org/bndtools/templating/util/CompositeOCD.java
+++ b/org.bndtools.templating/src/org/bndtools/templating/util/CompositeOCD.java
@@ -37,7 +37,7 @@ public class CompositeOCD extends BaseOCD {
             }
         }
         return ads.values()
-            .toArray(new AttributeDefinition[ads.size()]);
+            .toArray(new AttributeDefinition[0]);
     }
 
 }


### PR DESCRIPTION
Eclipse Photon now supports a separate classpath for test code.

Fixes #1904