### PR TITLE
[newproject] Follows workspace’s settings

### DIFF
--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -62,9 +62,7 @@ import bndtools.preferences.BndPreferences;
 public class Central implements IStartupParticipant {
 
     private static final ILogger logger = Logger.getLogger(Central.class);
-
     private static volatile Central instance = null;
-
     private static volatile Workspace workspace = null;
     private static final PromiseFactory promiseFactory = new PromiseFactory(Processor.getExecutor(), Processor.getScheduledExecutor());
     private static final Deferred<Workspace> workspaceQueue = promiseFactory.deferred();

--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizardPageTwo.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizardPageTwo.java
@@ -98,6 +98,6 @@ public class NewBndProjectWizardPageTwo extends NewJavaProjectWizardPageTwo {
         // we're okay if we have exactly at most two valid source paths
         // most templates use 2 source sets (main + test) but some do not
         // have the test source set
-        return resultFromSuperClass && (1 <= nr) && (nr <= 2);
+        return resultFromSuperClass && nr >= 1;
     }
 }


### PR DESCRIPTION
* ProjectPath changed to hold multiple sources and test sources
* New Wizard now creates class path entries according to the current workspace


Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>