### PR TITLE
build: Fix warning from Bnd about fragment host

### DIFF
--- a/org.bndtools.embeddedrepo/bnd.bnd
+++ b/org.bndtools.embeddedrepo/bnd.bnd
@@ -4,6 +4,8 @@
 Fragment-Host: biz.aQute.bndlib;bundle-version="[${bnd-version-base},${bnd-version-ceiling})"
 -includeresource: embedded-repo.jar=${repo;biz.aQute.bnd.embedded-repo;[${bnd-version-base},${bnd-version-ceiling});HIGHEST}
 
+-buildpath: ${bndlib}
+
 Import-Package: \
 	javax.management,\
 	javax.management.remote


### PR DESCRIPTION
`warning: Host biz.aQute.bndlib=bundle-version="[4.1.0,5.0.0)" for this fragment cannot be found on the classpath`