### PR TITLE
build: Some build cleanup

### DIFF
--- a/bndtools.api/bnd.bnd
+++ b/bndtools.api/bnd.bnd
@@ -2,9 +2,9 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
+	osgi.annotation; version=latest,\
+	osgi.core;version=latest, \
 	${bndlib}, \
-	osgi.annotation; version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version}, \
 	org.eclipse.equinox.common, \
 	org.eclipse.core.resources,\
 	org.eclipse.core.runtime,\

--- a/bndtools.bndplugins/bnd.bnd
+++ b/bndtools.bndplugins/bnd.bnd
@@ -2,9 +2,9 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
+	osgi.annotation; version=latest,\
 	${bndlib},\
 	${aQute-repository},\
-	osgi.annotation; version=${osgi.annotation.version},\
 	com.jcraft.jsch,\
 	org.eclipse.jgit
 

--- a/bndtools.builder/bnd.bnd
+++ b/bndtools.builder/bnd.bnd
@@ -2,15 +2,14 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath:  \
+	osgi.annotation; version=latest,\
+	osgi.core;version=latest,\
+	osgi.cmpn;version=latest,\
 	${bndlib};packages=*,\
 	${aQute-repository};packages=*,\
 	bndtools.api;version=latest,\
 	bndtools.utils;version=project;packages=*,\
 	bndtools.core;version=snapshot, \
-	osgi.annotation; version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
-	javax.xml,\
 	org.eclipse.osgi,\
 	org.eclipse.equinox.common,\
 	org.eclipse.equinox.registry,\

--- a/bndtools.core/bnd.bnd
+++ b/bndtools.core/bnd.bnd
@@ -75,15 +75,13 @@ eclipse.deps: \
 	org.eclipse.core.contenttype
 
 -buildpath: \
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	osgi.cmpn;version=latest,\
 	${bndlib},\
 	${aQute-repository};packages=*,\
 	${aQute-resolve},\
 	${eclipse.deps},\
-	javax.xml,\
-	javax.xml.stream,\
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
 	org.bndtools.versioncontrol.ignores.manager;version=latest,\

--- a/bndtools.jareditor/bnd.bnd
+++ b/bndtools.jareditor/bnd.bnd
@@ -5,9 +5,9 @@ Bundle-SymbolicName: bndtools.jareditor;singleton:=true
 -includeresource: resources
 
 -buildpath:  \
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
 	${bndlib};packages=*,\
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
 	org.eclipse.jface.text,\
 	org.eclipse.core.resources,\
 	org.eclipse.ui.editors,\

--- a/bndtools.m2e.debug.fragment/bnd.bnd
+++ b/bndtools.m2e.debug.fragment/bnd.bnd
@@ -3,6 +3,8 @@
 Bundle-SymbolicName: bndtools.m2e.debug.fragment; singleton:=true
 Fragment-Host: org.eclipse.m2e.maven.runtime
 
+-buildpath: org.eclipse.m2e.maven.runtime
+
 Import-Package: \
 	javax.net.ssl
 

--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -1,14 +1,14 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
-	org.slf4j.api;version=latest,\
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.core.version},\
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	osgi.cmpn;version=latest,\
 	${bndlib},\
 	biz.aQute.repository;version=latest,\
 	bndtools.api;version=latest,\
 	bndtools.core;version=latest,\
+	org.slf4j.api;version=latest,\
 	org.eclipse.m2e.maven.runtime,\
 	org.apache.maven:maven-artifact,\
 	org.apache.maven:maven-core,\

--- a/bndtools.pde/bnd.bnd
+++ b/bndtools.pde/bnd.bnd
@@ -1,6 +1,9 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	osgi.cmpn;version=latest,\
 	${bndlib},\
 	${aQute-resolve},\
 	bndtools.api;version=latest,\
@@ -17,10 +20,7 @@
 	org.eclipse.swt,\
 	org.eclipse.ui.workbench,\
 	org.eclipse.ui.ide,\
-	org.eclipse.osgi,\
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.core.version}
+	org.eclipse.osgi
 
 Bundle-SymbolicName: ${p}; singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/bndtools.release/bnd.bnd
+++ b/bndtools.release/bnd.bnd
@@ -21,13 +21,13 @@ Import-Package: !junit*,org.eclipse.core.runtime;registry=!,\
 					/=resources
 
 -buildpath:\
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	osgi.cmpn;version=latest,\
 	${bndlib},\
 	bndtools.utils;version=project;packages=*,\
 	bndtools.api;version=latest, \
 	bndtools.core;version=latest, \
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
 	org.eclipse.core.runtime,\
 	org.eclipse.core.contenttype,\
 	org.eclipse.jface,\

--- a/bndtools.utils/bnd.bnd
+++ b/bndtools.utils/bnd.bnd
@@ -2,11 +2,11 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
+	osgi.annotation;version=latest,\
+    osgi.core;version=latest, \
+    osgi.cmpn;version=latest, \
     ${bndlib}, \
     bndtools.api; version=latest, \
-	osgi.annotation;version=${osgi.annotation.version},\
-    osgi.core;version=${osgi.core.version}, \
-    osgi.cmpn;version=${osgi.cmpn.version}, \
     org.eclipse.osgi, \
     org.eclipse.equinox.common, \
     org.eclipse.equinox.registry, \

--- a/build/feature/bndtools/feature.xml
+++ b/build/feature/bndtools/feature.xml
@@ -227,18 +227,4 @@ This Agreement is governed by the laws of the State of New York and the intellec
          version="@org.slf4j.api-version@"
          unpack="false"/>
 
-   <plugin
-         id="javax.xml"
-         download-size="0"
-         install-size="0"
-         version="@javax.xml-version@"
-         unpack="false"/>
-
-   <plugin
-         id="javax.xml.stream"
-         download-size="0"
-         install-size="0"
-         version="@javax.xml.stream-version@"
-         unpack="false"/>
-
 </feature>

--- a/build/main.bnd
+++ b/build/main.bnd
@@ -1,9 +1,7 @@
 # Only extra bundles that are needed for the feature are mentioned here
 -resourceonly: true
 -includeresource: \
-    ${repo;biz.aQute.bndlib;[${bnd-version-base},${bnd-version-ceiling});HIGHEST},\
-    ${repo;biz.aQute.repository;[${bnd-version-base},${bnd-version-ceiling});HIGHEST},\
-    ${repo;biz.aQute.resolve;[${bnd-version-base},${bnd-version-ceiling});HIGHEST},\
-    ${repo;org.slf4j.api;latest},\
-    ${repo;javax.xml;latest},\
-    ${repo;javax.xml.stream;latest}
+    ${repo;biz.aQute.bndlib;latest},\
+    ${repo;biz.aQute.repository;latest},\
+    ${repo;biz.aQute.resolve;latest},\
+    ${repo;org.slf4j.api;latest}

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -26,19 +26,13 @@ base-version-qualifier:   DEV
 # Version of bnd/bndlib to use consistently throughout the build
 # NB. this must be specified as full M.m.u version (but no qualifier)
 # On advice of Peter we use an up-to-major version range
-bnd-version-base:         4.1.0
-bnd-version-ceiling:      5.0.0
-bndlib:                   aQute.libg;version='[${bnd-version-base},${bnd-version-ceiling})';strategy=highest, \
-                          biz.aQute.bndlib;version='[${bnd-version-base},${bnd-version-ceiling})';strategy=highest
+bndlib:                   aQute.libg;version=latest, \
+                          biz.aQute.bndlib;version=latest
 
 # Version of the repository plugin to use consistently throughout the build
 # NB. this must be specified as full M.m.u version (but no qualifier)
-aQute-repository:         biz.aQute.repository;version='[${bnd-version-base},${bnd-version-ceiling})';strategy=highest
-aQute-resolve:            biz.aQute.resolve;version='[${bnd-version-base},${bnd-version-ceiling})';strategy=highest
-
-osgi.annotation.version:  7.0.0
-osgi.core.version:        5.0.0
-osgi.cmpn.version:        5.0.0
+aQute-repository:         biz.aQute.repository;version=latest
+aQute-resolve:            biz.aQute.resolve;version=latest
 
 # We use git
 Git-Descriptor:           ${system-allow-fail;git describe --dirty --always --abbrev=9}

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -1,8 +1,6 @@
 org.osgi:osgi.annotation:7.0.0
 org.osgi:osgi.core:5.0.0
-org.osgi:osgi.core:6.0.0
 org.osgi:osgi.cmpn:5.0.0
-org.osgi:osgi.cmpn:6.0.0
 
 org.slf4j:slf4j-api:1.7.13
 org.slf4j:slf4j-simple:1.7.13

--- a/org.bndtools.embeddedrepo/bnd.bnd
+++ b/org.bndtools.embeddedrepo/bnd.bnd
@@ -1,8 +1,8 @@
 # Set javac settings from JDT prefs
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
-Fragment-Host: biz.aQute.bndlib;bundle-version="[${bnd-version-base},${bnd-version-ceiling})"
--includeresource: embedded-repo.jar=${repo;biz.aQute.bnd.embedded-repo;[${bnd-version-base},${bnd-version-ceiling});HIGHEST}
+Fragment-Host: biz.aQute.bndlib;bundle-version="[${base-version},${versionmask;=+0;${base-version}})"
+-includeresource: embedded-repo.jar=${repo;biz.aQute.bnd.embedded-repo;latest}
 
 -buildpath: ${bndlib}
 

--- a/org.bndtools.headless.build.manager/bnd.bnd
+++ b/org.bndtools.headless.build.manager/bnd.bnd
@@ -2,9 +2,9 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath:  \
-    bndtools.api;version=latest,\
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.cmpn;version=${osgi.cmpn.version}
+	osgi.annotation;version=latest,\
+	osgi.cmpn;version=latest,\
+    bndtools.api;version=latest
 	
 -testpath: \
 	${junit}

--- a/org.bndtools.headless.build.plugin.ant/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.ant/bnd.bnd
@@ -2,9 +2,9 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	osgi.cmpn;version=latest,\
 	${bndlib},\
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\
@@ -15,7 +15,7 @@
 
 -includeresource: \
 	templates=resources/templates/unprocessed,\
-	templates/cnf/plugins/biz.aQute.bnd/biz.aQute.bnd.jar=${repo;biz.aQute.bnd;[${bnd-version-base},${bnd-version-ceiling});HIGHEST}
+	templates/cnf/plugins/biz.aQute.bnd/biz.aQute.bnd.jar=${repo;biz.aQute.bnd;latest}
 
 # we really need this, otherwise Eclipse will not start our bundles
 Bundle-ActivationPolicy: lazy

--- a/org.bndtools.headless.build.plugin.gradle/bnd.bnd
+++ b/org.bndtools.headless.build.plugin.gradle/bnd.bnd
@@ -2,9 +2,9 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	osgi.cmpn;version=latest,\
 	${bndlib},\
 	bndtools.api;version=latest,\
 	org.bndtools.headless.build.manager;version=latest,\

--- a/org.bndtools.headless.build.plugin.gradle/resources/templates/filter/root/gradle.properties
+++ b/org.bndtools.headless.build.plugin.gradle/resources/templates/filter/root/gradle.properties
@@ -2,7 +2,7 @@
 bnd_cnf=cnf
 
 # bnd_plugin is the dependency declaration for the bnd gradle plugin
-bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:${bnd-version-base}
+bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:${base-version}
 
 # bnd_build can be set to the name of a "master" project whose dependencies will seed the set of projects to build.
 bnd_build=

--- a/org.bndtools.templating.gitrepo/bnd.bnd
+++ b/org.bndtools.templating.gitrepo/bnd.bnd
@@ -1,9 +1,9 @@
 # This bundle separated from core as it has a dependency on JGit.
 
 -buildpath: \
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core;version=${osgi.core.version},\
-	osgi.cmpn;version=${osgi.cmpn.version},\
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	osgi.cmpn;version=latest,\
 	${bndlib},\
 	bndtools.api; version=latest,\
 	org.bndtools.templating; version=latest,\

--- a/org.bndtools.templating/bnd.bnd
+++ b/org.bndtools.templating/bnd.bnd
@@ -2,9 +2,9 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath:\
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.core; version=${osgi.core.version},\
-	osgi.cmpn; version=${osgi.cmpn.version},\
+	osgi.annotation;version=latest,\
+	osgi.core; version=latest,\
+	osgi.cmpn; version=latest,\
 	${bndlib},\
 	${aQute-repository},\
 	org.eclipse.equinox.common,\

--- a/org.bndtools.versioncontrol.ignores.manager/bnd.bnd
+++ b/org.bndtools.versioncontrol.ignores.manager/bnd.bnd
@@ -2,9 +2,9 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath:  \
-    bndtools.api;version=latest,\
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.cmpn;version=${osgi.cmpn.version}
+	osgi.annotation;version=latest,\
+	osgi.cmpn;version=latest,\
+    bndtools.api;version=latest
 
 -testpath: \
 	${junit}

--- a/org.bndtools.versioncontrol.ignores.plugin.git/bnd.bnd
+++ b/org.bndtools.versioncontrol.ignores.plugin.git/bnd.bnd
@@ -2,10 +2,10 @@
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
 -buildpath: \
+	osgi.annotation;version=latest,\
+	osgi.cmpn;version=latest,\
 	bndtools.api;version=latest,\
-	org.bndtools.versioncontrol.ignores.manager;version=latest,\
-	osgi.annotation;version=${osgi.annotation.version},\
-	osgi.cmpn;version=${osgi.cmpn.version}
+	org.bndtools.versioncontrol.ignores.manager;version=latest
 
 -testpath: \
 	${junit}


### PR DESCRIPTION
Remove use of javax.xml bundles since the API is part of Java 8+. Use
repo contents to control version of osgi jars uses in build instead of
a variable.
