### PR TITLE
Remove the archived OSGi enRoute workspace template from the built in…

### DIFF
--- a/org.bndtools.templating.gitrepo/resources/processed/org/bndtools/templating/jgit/initialrepos.txt
+++ b/org.bndtools.templating.gitrepo/resources/processed/org/bndtools/templating/jgit/initialrepos.txt
@@ -1,1 +1,1 @@
-osgi/enroute.workspace;branch=origin/bnd-${version;==;${base-version}}, bndtools/workspace;branch=origin/${version;==;${base-version}}
+bndtools/workspace;branch=origin/${version;==;${base-version}}


### PR DESCRIPTION
… list

The OSGi enRoute V2 Bndtools workspace template has been archived, and is no longer being developed by the OSGi Alliance. It's also not a Bndtools managed project. This commit removes the OSGi enRoute V2 workspace template from the built-in list of workspace templates. The workspace template can easily be added back and used by individual users.

Signed-off-by: Tim Ward <timothyjward@apache.org>