### PR TITLE
templating: Make google appengine/apphosting package imports optional

### DIFF
--- a/org.bndtools.templating/bnd.bnd
+++ b/org.bndtools.templating/bnd.bnd
@@ -29,5 +29,7 @@ Bundle-ActivationPolicy: lazy
 
 # Disable ALL Eclipse split package attributes, to ensure we import from the "aggregator" bundle(s).
 Import-Package: sun.misc; resolution:=optional,\
+    com.google.appengine.*; resolution:=optional,\
+    com.google.apphosting.*; resolution:=optional,\
 	*;ui.workbench=!;common=!;registry=!;texteditor=!;text=!
 


### PR DESCRIPTION
The updated Bnd now finds Class.forName references to these packages
in guava and imports them. Since we do not really care about them, we
make the imports optional so we can resolve in Eclipse.
