### PR TITLE
gitrepo: Make sun package imports optional

### DIFF
--- a/org.bndtools.templating.gitrepo/bnd.bnd
+++ b/org.bndtools.templating.gitrepo/bnd.bnd
@@ -27,4 +27,6 @@ Bundle-ActivationPolicy: lazy
 Bundle-SymbolicName: org.bndtools.templating.gitrepo; singleton:=true
 # Disable ALL Eclipse split package attributes, to ensure we import from the "aggregator" bundle(s).
 Import-Package: \
+    sun.net.www.protocol.*; resolution:=optional,\
+    sun.security.*; resolution:=optional,\
 	*;ui.workbench=!;common=!;registry=!;texteditor=!;text=!


### PR DESCRIPTION
The updated Bnd now finds Class.forName references to these packages
in jgit and imports them. We make the imports optional so we can resolve
in Eclipse.