### PR TITLE
Add mavenCentral() to buildscript classpath 

### DIFF
--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -2,8 +2,8 @@ org.osgi:osgi.annotation:7.0.0
 org.osgi:osgi.core:5.0.0
 org.osgi:osgi.cmpn:5.0.0
 
-org.slf4j:slf4j-api:1.7.13
-org.slf4j:slf4j-simple:1.7.13
+org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-simple:1.7.25
 
 org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.12_1
 org.mockito:mockito-core:2.16.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ import aQute.bnd.osgi.Constants
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
   repositories {
+    mavenCentral()
     maven {
       url uri(bnd_repourl)
     }


### PR DESCRIPTION
This is now needed by the latest Bnd gradle plugin.